### PR TITLE
Polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Really sanding down the rough edges this time around.
+Really sanding down the rough edges this time around. This release includes significant ergonomic improvements to the high-level API.
 
 ### Added
 
@@ -23,6 +23,17 @@ Really sanding down the rough edges this time around.
 
 - Improved C++ Interoperability Recipes: Refined the C++ recipes to focus on direct interaction with C++ ABIs (mangled names, v-tables) rather than relying on C-style wrappers, showcasing more advanced use cases.
 - Improved `wchar_t` Guidance: Added a dedicated cookbook recipe explaining the best-practice for handling `wchar_t` and other semantic string types via the Type Registry, ensuring signatures are unambiguous and introspectable.
+- Enhanced High-Level API for Registered Types. The primary creation functions (`infix_forward_create`, `infix_forward_create_unbound`, `infix_reverse_create_callback`, and `infix_reverse_create_closure`) can now directly accept a registered named type as a signature.
+
+    ```c
+    // The high-level API now understands the "@Name" syntax directly.
+    // Assume the registry already has "@Adder_add_fn = (*{ val: int }, int) -> int;"
+    infix_reverse_create_callback(&ctx, "@Adder_add_fn", (void*)Adder_add, reg);
+    ```
+
+### Fixed
+
+-   Fixed a critical parsing bug in `infix_register_types` that occurred when defining a function pointer type alias (e.g., `@MyFunc = (...) -> ...;`). The preliminary parser for finding definition boundaries would incorrectly interpret the `>` in the `->` token as a closing delimiter, corrupting its internal nesting level calculation. This resulted in an `INFIX_CODE_UNEXPECTED_TOKEN` error and prevented the registration of function pointer types. The parser is now context-aware and correctly handles the `->` token, allowing for the clean and correct registration of function pointer aliases as intended.
 
 ## [0.1.0] - 2025-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
 Really sanding down the rough edges this time around.
 
- - Add `size_t` and `ssize_t` signature keywords
- - Add `char8_t`, `char16_t`, and `char32_t` aliases for integer types
+### Added
+
+- New Signature Keywords: Added keywords for common C and C++ types to improve signature readability and portability.
+  - Added `size_t` and `ssize_t` as platform-dependent abstract types.
+  - Added `char8_t`, `char16_t`, and `char32_t` as aliases for `uint8`, `uint16`, and `uint32` for better C++ interoperability.
+- Cookbook Examples: Extracted all recipes from the cookbook documentation into a comprehensive suite of standalone, compilable example programs located in the `eg/cookbook/` directory.
+- Advanced C++ Recipes: Added new, advanced cookbook recipes demonstrating direct, wrapper-free interoperability with core C++ features:
+  - Calling C++ virtual functions by emulating v-table dispatch.
+  - Bridging C-side stateful callbacks with C++ objects that expect `std::function` or similar callable objects.
+
+### Changed
+
+- Improved C++ Interoperability Recipes: Refined the C++ recipes to focus on direct interaction with C++ ABIs (mangled names, v-tables) rather than relying on C-style wrappers, showcasing more advanced use cases.
+- Improved `wchar_t` Guidance: Added a dedicated cookbook recipe explaining the best-practice for handling `wchar_t` and other semantic string types via the Type Registry, ensuring signatures are unambiguous and introspectable.
 
 ## [0.1.0] - 2025-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Here we go again...
+### Added
+
+Really sanding down the rough edges this time around.
+
+ - Add `size_t` and `ssize_t` signature keywords
+ - Add `char8_t`, `char16_t`, and `char32_t` aliases for integer types
 
 ## [0.1.0] - 2025-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,11 @@ Really sanding down the rough edges this time around. This release includes sign
     infix_reverse_create_callback(&ctx, "@Adder_add_fn", (void*)Adder_add, reg);
     ```
 
+- The `infix_read_global` and `infix_write_global` functions now take an additional `infix_registry_t*` argument to support reading and writing global variables that are defined by a named type (e.g., `@MyStruct`).
+
 ### Fixed
 
--   Fixed a critical parsing bug in `infix_register_types` that occurred when defining a function pointer type alias (e.g., `@MyFunc = (...) -> ...;`). The preliminary parser for finding definition boundaries would incorrectly interpret the `>` in the `->` token as a closing delimiter, corrupting its internal nesting level calculation. This resulted in an `INFIX_CODE_UNEXPECTED_TOKEN` error and prevented the registration of function pointer types. The parser is now context-aware and correctly handles the `->` token, allowing for the clean and correct registration of function pointer aliases as intended.
+- Fixed a critical parsing bug in `infix_register_types` that occurred when defining a function pointer type alias (e.g., `@MyFunc = (...) -> ...;`). The preliminary parser for finding definition boundaries would incorrectly interpret the `>` in the `->` token as a closing delimiter, corrupting its internal nesting level calculation. This resulted in an `INFIX_CODE_UNEXPECTED_TOKEN` error and prevented the registration of function pointer types. The parser is now context-aware and correctly handles the `->` token, allowing for the clean and correct registration of function pointer aliases as intended.
 
 ## [0.1.0] - 2025-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will (I hope) be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2025-11-01
 
 Really sanding down the rough edges this time around. This release includes significant ergonomic improvements to the high-level API.
 

--- a/README.md
+++ b/README.md
@@ -1,152 +1,60 @@
-# infix: A JIT-Powered FFI Library for C
+# `infix`: A JIT-powered FFI library for C
 
-[![CI](https://github.com/sanko/infix/actions/workflows/ci.yml/badge.svg)](https://github.com/sanko/infix/actions/workflows/ci.yml) ([Matrix](#supported-platforms))
+`infix` is a modern, lightweight C library that lets you call any C function or create C callbacks at runtime, using simple, human-readable strings to describe the function's signature.
 
-`infix` is a modern, security-conscious, and dependency-free Foreign Function Interface (FFI) library for C. It solves the complex problem of calling native functions across language boundaries, replacing brittle, hand-written binding code with a simple, human-readable signature string like `({int, *double}, *char) -> int`.
+It's designed to be the simplest way to add a dynamic Foreign Function Interface (FFI) to your project, whether you're building a language runtime, a plugin system, or just need to call functions from a dynamically loaded library.
 
-At its core, `infix` is a Just-in-Time (JIT) compiler that generates tiny, highly-optimized machine code "trampolines" at runtime. These trampolines correctly handle the low-level Application Binary Interface (ABI) for the target platform, ensuring seamless and performant interoperability.
-
-## Documentation
-
-*   **[Cookbook](docs/cookbook.md):** The best place to start. A comprehensive guide with practical, copy-pasteable recipes for common FFI tasks.
-*   **[Signature Reference](docs/signatures.md):** The complete guide for the `infix` signature mini-language spec.
-*   **[Internals](docs/internals.md):** A deep dive into the library's architecture for maintainers and contributors.
-*   **[Porting Guide](docs/porting.md):** A guide for porting `infix` to new CPU architectures and ABIs.
-*   **[INSTALL.md](docs/INSTALL.md):** Detailed build and integration instructions.
-
-## How It Works: The Trampoline Concept
-
-At its core, `infix` generates a small piece of executable machine code called a **trampoline**. This code acts as an intelligent adapter that understands the specific calling convention (ABI) of your platform.
-
-#### Forward Call (e.g., from Python to C)
-
-When your application wants to call a C function, it doesn't call it directly. Instead, it calls the `infix` trampoline, which handles the complex process of placing arguments in the correct CPU registers and on the stack before making the final jump to the target C function.
-
-```mermaid
-graph LR
-  subgraph "Forward Call (e.g., Python to C)"
-    A["Your App<br/>(e.g., Python)"] -->|1. Call with generic `void**` arguments| B["infix Trampoline<br/>(JIT-compiled)"];
-    B -->|2. Sets up ABI, places args<br/>in registers & stack| C["Native C Function<br/>(e.g., puts())"];
-  end
-```
-
-#### Reverse Call (e.g., from C back to Python)
-
-`infix` generates a native C function pointer that a C library can call. When called, this JIT-compiled stub marshals the native arguments back into a generic format and invokes your high-level handler.
-
-```mermaid
-graph LR
-  subgraph "Reverse Call (e.g., C to Python)"
-    D["Native C Code<br/>(e.g., a GUI library)"] -->|1. Calls native function pointer<br/>with C arguments| E["infix Callback<br/>(JIT-compiled)"];
-    E -->|2. Marshals ABI arguments<br/>and invokes handler| F["Your App's Handler<br/>(e.g., Python function)"];
-  end
-```
-
-## Who is this for?
-
-`infix` is designed for developers who need to bridge the gap between different codebases or language runtimes. You'll find it especially useful if you are:
-
-*   **A Language Binding Author:** `infix` is the ideal engine for allowing a high-level language like Python, Ruby, Perl, or Lua to call C libraries. The introspectable type system simplifies the complex task of data marshalling.
-*   **A Plugin System Architect:** Build a stable, ABI-agnostic plugin system. `infix` can provide the boundary layer, allowing you to load and call functions from shared libraries without tight coupling.
-*   **A C/C++ Developer:** Dynamically call functions from system libraries (`user32.dll`, `libc.so.6`, etc.) without needing to link against them at compile time, or create complex stateful callbacks for C APIs.
-*   **A Security Researcher:** `infix` provides a powerful, fuzz-tested toolkit for analyzing and interacting with native code.
-
-> **How does `infix` compare to alternatives like libffi and`dyncall?**
->
-> `infix` shares a similar goal with these popular libraries but differs in its design philosophy.
->
-> - Compared to libffi, `infix` prioritizes a modern, security-hardened architecture (W^X memory, guard pages), a more expressive and readable string-based API, and a powerful named type registry for managing complex data structures.
-> - Compared to dyncall, `infix` offers a declarative API via its signature strings. Where dyncall uses an imperative, programmatic sequence of calls (e.g., `dcArgInt(vm, 10); dcArgString(vm, "hi");`), `infix` defines the entire function prototype in a single, self-contained, and human-readable string. This makes signatures easy to log, store in configuration, and manage, especially for complex types.
+[![CI](https://github.com/sanko/infix/actions/workflows/ci.yml/badge.svg)](#supported-platforms)
 
 ## Key Features
 
--   **Zero Dependencies & Simple Integration:** `infix` uses a unity build, making integration into any C/C++ project trivial by simply compiling `src/infix.c`.
--   **Simple, Powerful APIs:** Use the high-level **Signature API** to create trampolines from a single string, or drop down to the memory-safe **Manual API** for dynamic, performance-critical use cases.
--   **Advanced Type System:** Full support for primitives, pointers, structs, unions, arrays, enums, `_Complex` numbers, and architecture-specific SIMD vectors (**SSE, AVX, AVX-512, NEON, and SVE**).
--   **Named Type Registry:** Define complex types like structs and unions once, and reuse them by name (`@Name`) across all your signatures for unparalleled readability and maintainability.
--   **Stateful Callbacks Made Easy:** The reverse-call API is designed to make stateful callbacks simple and safe, even when the C library you're calling doesn't provide a `user_data` parameter. It offers both high-level, type-safe handlers for C/C++ and low-level, generic handlers for language bindings.
--   **Secure by Design:** `infix` is hardened against vulnerabilities and validated through extensive fuzz testing:
-    *   **W^X Memory Protection:** JIT-compiled code is never writable and executable at the same time.
-    *   **Guard Pages:** Freed trampolines are made inaccessible to prevent **use-after-free** bugs.
-    *   **Read-Only Contexts:** Callback context data is made read-only to guard against runtime **memory corruption**.
--   **Cross-Platform and Cross-Architecture:** Designed for portability, with initial support for **x86-64** (System V and Windows x64) and **AArch64** (AAPCS64).
--   **Arena-Based Memory:** Utilizes an efficient arena allocator for all type descriptions, ensuring fast performance and leak-free memory management.
--   **Dynamic Library Tools**: A cross-platform API to load shared libraries (`.so`, `.dll`, `.dylib`), look up symbols, and read/write global variables using the same powerful signature system.
+*   **Human-Readable Signatures:** Describe complex C functions with an intuitive string format (e.g., `"({double, double}, int) -> *char"`).
+*   **Forward & Reverse Calls:** Call C functions ("forward") and create C function pointers that call back into your code ("reverse").
+*   **Simple Integration:** Add a single C file and a header directory to your project to get started. No complex dependencies.
+*   **Type Registry:** Define, reuse, and link complex, recursive, and mutually-dependent structs by name.
+*   **Security-First Design:** Hardened against vulnerabilities with Write XOR Execute (W^X) memory, guard pages, and fuzz testing.
+*   **High Performance:** A Just-in-Time (JIT) compiler generates optimized machine code trampolines, making calls nearly as fast as a direct C call after the initial setup.
 
-## Performance
+## Full Documentation
 
-`infix` is designed for high performance, balancing the flexibility of dynamic calls with the speed of compiled code.
+*   [Installation Guide](docs/INSTALL.md): How to build and integrate `infix`.
+*   [API Quick Reference](docs/API.md): A complete reference for the public API.
+*   [The FFI Cookbook](docs/cookbook.md): Practical, real-world examples and recipes.
+*   [Signature Language Reference](docs/signatures.md): A deep dive into the signature string format.
+*   [Porting Guide](docs/porting.md): Instructions for adding support for a new CPU architecture or ABI.
+*   [Contributing Guide](CONTRIBUTING.md): How to contribute to the project.
 
-*   **Call Overhead:** The overhead of a call through a **bound** trampoline is extremely low, typically measuring in the single-digit nanoseconds on modern hardware. This makes it suitable for performance-critical loops. **Unbound** trampolines offer more flexibility at the cost of a small, additional overhead.
-*   **Generation Time:** Creating a new trampoline is fast, typically taking only a few microseconds. This allows for dynamic generation of callbacks and function calls in response to runtime events without noticeable latency.
+---
 
-The library includes micro-benchmarks to track these metrics and prevent performance regressions.
+## How It Works: A Quick Example
 
-## Getting Started
-
-Full build instructions for `xmake`, `cmake`, GNU `make`, and other systems are available in **[INSTALL.md](docs/INSTALL.md)**.
-
-### Prerequisites
-
--   A C11-compatible compiler (GCC, Clang, or MSVC).
--   (Optional) A build tool like `cmake`, `xmake`, `make`, etc.
-
-### Building the Library
-
-While you can use the provided build scripts, the simplest way to build `infix` is to compile its single translation unit directly. Because `infix` uses a unity build, integration into an existing project is simple: add `src/infix.c` to your list of source files and add the `include/` directory to your include paths.
-
-```bash
-# Build a static library on Linux/macOS
-gcc -c -std=c11 -O2 -I/path/to/infix/include src/infix.c -o infix.o
-ar rcs libinfix.a infix.o
-
-# Build a static library with MSVC
-cl.exe /c /I C:\path\to\infix\include /O2 src\infix.c /Foinfix.obj
-lib.exe /OUT:infix.lib infix.obj
-```
-
-### Integrating into Your Project
-
-1.  **Include the Header:**
-
-    ```c
-    #include <infix/infix.h>
-    ```
-
-2.  **Link the Library:** When compiling your application, link against the `libinfix.a` (or `infix.lib`) library.
-
-    ```bash
-    gcc my_app.c -I/path/to/infix/include -L/path/to/build/dir -linfix -o my_app
-    ```
-
-### Quick Start: A 60-Second Example
-
-Here is a complete, runnable example that calls the standard C library function `puts`.
+The heart of `infix` is its signature string. Here’s how you would call a simple C function:
 
 ```c
-#include <stdio.h>
 #include <infix/infix.h>
+#include <stdio.h>
+
+// The C function we want to call.
+int add(int a, int b) { return a + b; }
 
 int main() {
-    // 1. Describe the function signature: int puts(const char*);
-    const char* signature = "(*char) -> int32";
+    // 1. Describe the function's signature as a string.
+    const char* signature = "(int, int) -> int";
 
-    // 2. Create a "bound" trampoline, hardcoding the address of `puts`.
-    //    Pass nullptr for the registry as we are not using named types.
+    // 2. Create a "trampoline"—a JIT-compiled function wrapper.
     infix_forward_t* trampoline = NULL;
-    infix_forward_create(&trampoline, signature, (void*)puts, NULL);
-
-    // 3. Get the callable function pointer.
+    infix_forward_create(&trampoline, signature, (void*)add, NULL);
     infix_cif_func cif = infix_forward_get_code(trampoline);
 
-    // 4. Prepare arguments and call.
-    //    The `args` array must contain *pointers* to your argument values.
-    const char* my_string = "Hello from infix!";
-    void* args[] = { &my_string };
-    int return_value;
-    cif(&return_value, args); // A non-negative value is returned on success.
+    // 3. Prepare an array of *pointers* to the arguments.
+    int a = 10, b = 32;
+    void* args[] = { &a, &b };
+    int result;
 
-    printf("puts returned: %d\n", return_value);
+    // 4. Call the function through the trampoline.
+    cif(&result, args);
+
+    printf("Result: %d\n", result); // Output: Result: 42
 
     // 5. Clean up.
     infix_forward_destroy(trampoline);
@@ -154,113 +62,61 @@ int main() {
 }
 ```
 
-## API Reference
+## Creating Callbacks
 
-A brief overview of the complete public API, grouped by functionality.
+`infix` can also generate native C function pointers that call back into your code. This is perfect for interfacing with C libraries that expect callbacks, like `qsort`.
 
-<details>
-<summary><b>Click to expand Full API Reference</b></summary>
+```c
+#include <infix/infix.h>
+#include <stdlib.h>
 
-### Named Type Registry (`registry_api`)
-- `infix_registry_create()`: Creates a new, empty type registry.
-- `infix_registry_destroy()`: Frees a registry and all types defined within it.
-- `infix_register_types()`: Parses a string of definitions to populate a registry.
+// The C handler function for our callback.
+int compare_integers(const void* a, const void* b) {
+    return (*(const int*)a - *(const int*)b);
+}
 
-### Registry Introspection (`registry_introspection_api`)
-- `infix_registry_print()`: Serializes all defined types in a registry to a string.
-- `infix_registry_iterator_begin()`: Creates an iterator to traverse the types in a registry.
-- `infix_registry_iterator_next()`: Advances the iterator to the next type.
-- `infix_registry_iterator_get_name()`: Gets the name of the type at the current iterator position.
-- `infix_registry_iterator_get_type()`: Gets the `infix_type` at the current iterator position.
-- `infix_registry_is_defined()`: Checks if a type name is fully defined in the registry.
-- `infix_registry_lookup_type()`: Retrieves a canonical `infix_type` from the registry by name.
+void run_qsort_example() {
+    // 1. Describe the callback's signature.
+    const char* cmp_sig = "(*void, *void) -> int";
 
-### High-Level Signature API (`high_level_api`)
-- `infix_forward_create()`: Creates a bound forward trampoline from a signature.
-- `infix_forward_create_unbound()`: Creates an unbound forward trampoline from a signature.
-- `infix_reverse_create_callback()`: Creates a type-safe reverse trampoline (for C/C++ developers).
-- `infix_reverse_create_closure()`: Creates a generic reverse trampoline (for language bindings).
-- `infix_signature_parse()`: Parses a full function signature into its `infix_type` components.
-- `infix_type_from_signature()`: Parses a string representing a single data type.
+    // 2. Create a reverse trampoline.
+    infix_reverse_t* context = NULL;
+    infix_reverse_create_callback(&context, cmp_sig, (void*)compare_integers, NULL);
 
-### Dynamic Library & Globals API (`exports_api`)
-- `infix_library_open()`: Opens a dynamic library (`.so`, `.dll`).
-- `infix_library_close()`: Closes a dynamic library handle.
-- `infix_library_get_symbol()`: Retrieves a function or variable address from a library.
-- `infix_read_global()`: Reads a global variable from a library using a signature.
-- `infix_write_global()`: Writes to a global variable in a library using a signature.
+    // 3. Get the JIT-compiled C function pointer.
+    int (*my_comparator)(const void*, const void*) = infix_reverse_get_code(context);
 
-### Manual Trampoline API (`manual_api`)
-- `infix_forward_create_manual()`: Creates a bound forward trampoline from `infix_type` objects.
-- `infix_forward_create_unbound_manual()`: Creates an unbound forward trampoline from `infix_type` objects.
-- `infix_reverse_create_callback_manual()`: Creates a type-safe reverse trampoline from `infix_type` objects.
-- `infix_reverse_create_closure_manual()`: Creates a generic reverse trampoline from `infix_type` objects.
-- `infix_forward_destroy()`: Frees a forward trampoline.
-- `infix_reverse_destroy()`: Frees a reverse trampoline.
+    // 4. Use the generated callback with the C library function.
+    int numbers[] = { 5, 1, 4, 2, 3 };
+    qsort(numbers, 5, sizeof(int), my_comparator);
+    // `numbers` is now sorted: [1, 2, 3, 4, 5]
 
-### Manual Type Creation API (`type_system`)
-- `infix_type_create_primitive()`: Gets a static descriptor for a primitive C type.
-- `infix_type_create_pointer()`: Gets a static descriptor for `void*`.
-- `infix_type_create_pointer_to()`: Creates a pointer type with a specific pointee type.
-- `infix_type_create_void()`: Gets the static descriptor for the `void` type.
-- `infix_type_create_struct()`: Creates a struct type from an array of members.
-- `infix_type_create_packed_struct()`: Creates a struct with non-standard packing.
-- `infix_type_create_union()`: Creates a union type from an array of members.
-- `infix_type_create_array()`: Creates a fixed-size array type.
-- `infix_type_create_enum()`: Creates an enum type with an underlying integer type.
-- `infix_type_create_complex()`: Creates a `_Complex` number type.
-- `infix_type_create_vector()`: Creates a SIMD vector type.
-- `infix_type_create_named_reference()`: Creates a placeholder for a named type to be resolved by a registry.
-- `infix_type_create_member()`: A factory function to create an `infix_struct_member`.
+    infix_reverse_destroy(context);
+}
+```
 
-### Memory Management (`memory_management`)
-- `infix_arena_create()`: Creates a new memory arena.
-- `infix_arena_destroy()`: Frees an arena and all memory allocated from it.
-- `infix_arena_alloc()`: Allocates aligned memory from an arena.
-- `infix_arena_calloc()`: Allocates zero-initialized memory from an arena.
+## Getting Started
 
-### Introspection API (`introspection_api`)
-#### Trampoline & Callback Introspection
-- `infix_forward_get_code()`: Gets the callable function pointer from a bound trampoline.
-- `infix_forward_get_unbound_code()`: Gets the callable function pointer from an unbound trampoline.
-- `infix_reverse_get_code()`: Gets the native C function pointer from a reverse trampoline.
-- `infix_reverse_get_user_data()`: Gets the user-provided data from a closure.
-- `infix_forward_get_num_args()`: Gets the total number of arguments for a forward trampoline.
-- `infix_forward_get_num_fixed_args()`: Gets the number of fixed (non-variadic) arguments.
-- `infix_forward_get_return_type()`: Gets the return type for a forward trampoline.
-- `infix_forward_get_arg_type()`: Gets the type of a specific argument for a forward trampoline.
-- `infix_reverse_get_num_args()`: Gets the total number of arguments for a reverse trampoline.
-- `infix_reverse_get_num_fixed_args()`: Gets the number of fixed (non-variadic) arguments.
-- `infix_reverse_get_return_type()`: Gets the return type for a reverse trampoline.
-- `infix_reverse_get_arg_type()`: Gets the type of a specific argument for a reverse trampoline.
-#### Type Introspection & Serialization
-- `infix_type_get_category()`: Gets the fundamental category of a type (e.g., struct, pointer).
-- `infix_type_get_size()`: Gets the size of a type in bytes.
-- `infix_type_get_alignment()`: Gets the alignment of a type in bytes.
-- `infix_type_get_member_count()`: Gets the number of members in a struct or union.
-- `infix_type_get_member()`: Gets a specific member from a struct or union by index.
-- `infix_type_get_arg_name()`: Gets the name of an argument from a function type.
-- `infix_type_get_arg_type()`: Gets the type of an argument from a function type.
-- `infix_type_print()`: Serializes an `infix_type` graph back to a signature string.
-- `infix_function_print()`: Serializes a full function signature to a string.
+The easiest way to use `infix` is to add its source directly to your project.
 
-### Error Handling API (`error_api`)
-- `infix_get_last_error()`: Retrieves detailed information about the last error on the current thread.
+1.  Copy the `src/` and `include/` directories into your project.
+2.  Add `src/infix.c` to your build system's list of source files.
+3.  Add the `include/` directory to your include paths.
+4.  `#include <infix/infix.h>` in your code.
 
-</details>
+For more advanced build options, including building as a standalone library with CMake or xmake, see the [Building and Integration Guide](docs/INSTALL.md).
 
-## Building and Integrating
+## Project Philosophy
 
-Full build instructions for `xmake`, `cmake`, GNU `make`, and other systems are available in **[INSTALL.md](docs/INSTALL.md)**.
+`infix` is built on three core principles:
 
-Because `infix` uses a unity build, integration into an existing project is simple: add `src/infix.c` to your list of source files and add the `include/` directory to your include paths.
+1.  **Security First:** An FFI library with a JIT is a prime target for vulnerabilities. We defend against these with a multi-layered approach, including strict W^X memory, hardened integer arithmetic, and continuous fuzz testing.
+2.  **Performance by Design:** FFI overhead should be minimal. `infix` separates the one-time **generation cost** from the near-zero **call-time cost**, making it exceptionally fast in high-performance applications when trampolines are cached.
+3.  **Simplicity and Portability:** Platform- and ABI-specific logic is strictly isolated, making the library easy to maintain, simple to integrate, and straightforward to port to new architectures.
 
-## Supported Platforms
+## Platform Support
 
 `infix` is rigorously tested on a wide array of operating systems, compilers, and architectures with every commit.
-
-<details>
-<summary><b>Click to expand Full Platform CI Results</b></summary>
 
 | OS           | Version     | Architecture | Compiler  | Status                                                                                                                                                                                               |
 | :----------- | :---------- | :----------- | :-------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -290,26 +146,10 @@ Because `infix` uses a unity build, integration into an existing project is simp
 |              | Server 2025 | x86-64       | GCC       | ![windows/x64/gcc     ](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fsankorobinson.com%2Finfix%2Fstatus%2Fstatus.json&style=for-the-badge&label=%20&query=windows-x86_64-gcc) |
 |              | Server 2025 | x86-64       | MSVC      | ![windows/x64/msvc    ](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fsankorobinson.com%2Finfix%2Fstatus%2Fstatus.json&style=for-the-badge&label=%20&query=windows-x86_64-msvc) |
 
-</details>
-
 In addition to the CI platforms tested here on Github, I can verify infix builds and passes unit tests on Android/Termux.
 
-## Contributing
+## Licenses
 
-Contributions are welcome! Please feel free to submit a pull request or open an issue for any bugs, feature requests, or documentation improvements.
+To maximize usability for all, `infix` is dual-licensed under the [Artistic License 2.0](LICENSE-A2)  and the [MIT License](LICENSE-MIT). You may choose to use the code under the terms of either license.
 
-## License & Legal
-
-`infix` is provided under multiple licenses to maximize its usability for all.
-
-### Code License
-
-Source code, including header files (`.h`) and implementation files (`.c`), is dual-licensed under the **Artistic License 2.0** or the **MIT License**. You may choose to use the code under the terms of either license.
-
-See the [LICENSE-A2](LICENSE-A2) and/or [LICENSE-MIT](LICENSE-MIT) for the full text of both licenses.
-
-### Documentation License
-
-At your discretion, all standalone documentation (`.md`), explanatory text, Doxygen-style documentation blocks, comments, and code examples contained within this repository may be used, modified, and distributed under the terms of the **Creative Commons Attribution 4.0 International License (CC BY 4.0)**. We encourage you to share and adapt the documentation for any purpose (generating an API reference website, creating tutorials, etc.), as long as you give appropriate credit.
-
-See the [LICENSE-CC](LICENSE-CC) for details.
+At your discretion, all standalone documentation (`.md`), explanatory text, Doxygen-style documentation blocks, comments, and code examples contained within this repository may be used, modified, and distributed under the terms of the  [Creative Commons Attribution 4.0 International License (CC BY 4.0)](LICENSE-CC). I encourage you to share and adapt the documentation for any purpose (generating an API reference website, creating tutorials, etc.), as long as you give appropriate credit.

--- a/build.pl
+++ b/build.pl
@@ -920,7 +920,7 @@ sub compile_shared_lib {
     my $is_cpp       = ( $source =~ /\.cpp$/ );
     my $lib_prefix   = $config->{is_windows} ? '' : 'lib';
     my $output_path  = $config->{bin_dir} . '/' . $lib_prefix . $name . '.' . $Config{so};
-    my @local_cflags = $is_cpp ? @{ $config->{cxxflags} } : @{ $config->{cflags} };
+    my @local_cflags = grep { $_ ne '-O2' } $is_cpp ? @{ $config->{cxxflags} } : @{ $config->{cflags} };
     my @cmd          = ( $compiler, @local_cflags, @$flags, '-o', $output_path, $source );
     push @cmd, @$deps if $deps;
     run_command(@cmd);

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,255 @@
+# `infix` API Quick Reference
+
+This document provides a concise reference for the public API of the `infix` library. It's designed to be a quick lookup for developers who are already familiar with the library's concepts.
+
+For practical, in-depth examples, please see the [Cookbook](cookbook.md).
+
+## Table of Contents
+
+*   [1. High-Level Signature API](#1-high-level-signature-api)
+    *   [Forward Trampolines (Calling C)](#forward-trampolines-calling-c)
+    *   [Reverse Trampolines (Callbacks & Closures)](#reverse-trampolines-callbacks--closures)
+*   [2. Error Handling API](#2-error-handling-api)
+    *   [The Error Handling Pattern](#the-error-handling-pattern)
+    *   [Common Error Categories](#common-error-categories)
+*   [3. Introspection API](#3-introspection-api)
+    *   [Getting Callable Code](#getting-callable-code)
+    *   [Inspecting Trampoline Properties](#inspecting-trampoline-properties)
+    *   [Inspecting Type Properties](#inspecting-type-properties)
+*   [4. Named Type Registry API](#4-named-type-registry-api)
+    *   [Creation and Population](#creation-and-population)
+    *   [Registry Introspection & Iteration](#registry-introspection--iteration)
+*   [5. Dynamic Library & Globals API](#5-dynamic-library--globals-api)
+*   [6. Manual API (Advanced)](#6-manual-api-advanced)
+    *   [Manual Trampoline Creation](#manual-trampoline-creation)
+    *   [Manual Type Creation](#manual-type-creation)
+*   [7. Memory Management (Arenas)](#7-memory-management-arenas)
+
+---
+
+## 1. High-Level Signature API
+
+These are the primary, recommended functions for creating trampolines from human-readable signature strings.
+
+### Forward Trampolines (Calling C)
+
+#### `infix_forward_create`
+Creates a high-performance "bound" trampoline compiled for a *specific* C function. This is the fastest way to call the same function repeatedly.
+
+```c
+infix_status infix_forward_create(
+    infix_forward_t** out_trampoline,
+    const char* signature,
+    void* target_function,
+    infix_registry_t* registry
+);
+```
+
+#### `infix_forward_create_unbound`
+Creates a more flexible "unbound" trampoline for a given signature. The target function is provided at call time, allowing you to reuse one trampoline for multiple functions with the same signature.
+
+```c
+infix_status infix_forward_create_unbound(
+    infix_forward_t** out_trampoline,
+    const char* signature,
+    infix_registry_t* registry
+);
+```
+
+### Reverse Trampolines (Callbacks & Closures)
+
+#### `infix_reverse_create_callback`
+Creates a reverse trampoline for a type-safe C function. This is the easiest way to create a callback for a C library like `qsort`.
+
+```c
+infix_status infix_reverse_create_callback(
+    infix_reverse_t** out_context,
+    const char* signature,
+    void* user_callback_fn,
+    infix_registry_t* registry
+);
+```
+
+#### `infix_reverse_create_closure`
+Creates a reverse trampoline with a generic handler. This is the ideal choice for creating stateful callbacks or for language bindings, as it gives you low-level control and a `user_data` pointer to maintain state.
+
+```c
+infix_status infix_reverse_create_closure(
+    infix_reverse_t** out_context,
+    const char* signature,
+    infix_closure_handler_fn user_callback_fn,
+    void* user_data,
+    infix_registry_t* registry
+);
+```
+
+---
+
+## 2. Error Handling API
+
+Error handling in `infix` is designed to be both detailed and thread-safe. All detailed error information is stored in thread-local storage, so an error in one thread won't affect another.
+
+### The Error Handling Pattern
+
+The basic pattern is to always check the `infix_status` return value of an API function. If it's anything other than `INFIX_SUCCESS`, you can get more details.
+
+```c
+infix_error_details_t infix_get_last_error(void);
+```
+
+This function returns a copy of an `infix_error_details_t` struct, which contains everything you need to know about what went wrong:
+
+*   `category`: A high-level category like `INFIX_CATEGORY_PARSER`.
+*   `code`: A specific error code like `INFIX_CODE_UNEXPECTED_TOKEN`.
+*   `position`: For parser errors, the exact character position in the signature string where the error occurred.
+*   `message`: A detailed, human-readable error message.
+
+### Common Error Categories
+
+#### Parser Errors (`INFIX_CATEGORY_PARSER`)
+**What it means:** There is a syntax error in a signature string you provided.
+**How to handle:** This is the most common type of error. You can use the `position` and `message` from the error details to provide a rich diagnostic to the user, much like a compiler would.
+
+```c
+// Example: Handling a parser error
+infix_status status = infix_type_from_signature(&type, &arena, "{int, ^double}", NULL);
+
+if (status != INFIX_SUCCESS) {
+    infix_error_details_t err = infix_get_last_error();
+    fprintf(stderr, "Error parsing signature:\n");
+    fprintf(stderr, "  %s\n", "{int, ^double}");
+    fprintf(stderr, "  %*s^\n", (int)err.position, ""); // Print a caret
+    fprintf(stderr, "Details: %s\n", err.message);
+}
+```
+
+#### Allocation Errors (`INFIX_CATEGORY_ALLOCATION`)
+**What it means:** The library failed to allocate memory, either from the standard heap (`malloc`) or from the OS for executable JIT code (`mmap`/`VirtualAlloc`). This usually means the system is out of memory.
+**How to handle:** There is often little you can do to recover. The best course of action is to log the error and terminate the process gracefully.
+
+#### ABI & Layout Errors (`INFIX_CATEGORY_ABI`)
+**What it means:** This is a more subtle category of error related to the function's structure.
+*   You used a named type (e.g., `@Point`) in a signature but didn't provide a registry, or the name wasn't found.
+*   You tried to create an invalid type, like a struct containing a `void` member.
+*   A type was too large or complex for the target architecture's ABI to handle (e.g., a struct larger than the maximum safe stack allocation size).
+**How to handle:** Double-check your signature strings and type definitions in the registry. Ensure you are passing the correct registry handle to the creation function.
+
+#### General & Library Errors
+**What it means:** This is a catch-all for other issues.
+*   You passed an invalid argument to an API function (e.g., `NULL` where a valid pointer was required).
+*   When using the dynamic library API, the requested library (`.so`, `.dll`) could not be found or a symbol lookup failed.
+**How to handle:** For library errors, ensure the shared library file is in the expected location (e.g., the current directory, or a system path). For other errors, review the arguments you are passing to the `infix` function call.
+
+---
+
+## 3. Introspection API
+
+Functions for inspecting the properties of trampolines and types at runtime.
+
+### Getting Callable Code
+
+*   `infix_cif_func infix_forward_get_code(infix_forward_t* trampoline)`: Gets the callable function pointer from a **bound** forward trampoline.
+*   `infix_unbound_cif_func infix_forward_get_unbound_code(infix_forward_t* trampoline)`: Gets the callable function pointer from an **unbound** forward trampoline.
+*   `void* infix_reverse_get_code(const infix_reverse_t* context)`: Gets the native C function pointer from a reverse trampoline.
+*   `void* infix_reverse_get_user_data(const infix_reverse_t* context)`: Gets the `user_data` pointer from a closure.
+
+### Inspecting Trampoline Properties
+
+These functions work for both `infix_forward_t*` and `infix_reverse_t*` handles.
+
+*   `size_t infix_forward_get_num_args(const infix_forward_t* handle)`: Returns the total number of arguments.
+*   `size_t infix_forward_get_num_fixed_args(const infix_forward_t* handle)`: Returns the number of non-variadic arguments.
+*   `const infix_type* infix_forward_get_return_type(const infix_forward_t* handle)`: Returns the `infix_type` for the return value.
+*   `const infix_type* infix_forward_get_arg_type(const infix_forward_t* handle, size_t index)`: Returns the `infix_type` for the argument at `index`.
+
+*(Note: The `infix_reverse_*` variants have the same function signatures.)*
+
+### Inspecting Type Properties
+
+*   `infix_status infix_type_from_signature(...)`: Parses a signature string into a detailed `infix_type` graph.
+*   `infix_type_category infix_type_get_category(const infix_type* type)`: Returns the fundamental category (e.g., `INFIX_TYPE_STRUCT`).
+*   `size_t infix_type_get_size(const infix_type* type)`: Returns the size of the type in bytes.
+*   `size_t infix_type_get_alignment(const infix_type* type)`: Returns the alignment requirement in bytes.
+*   `size_t infix_type_get_member_count(const infix_type* type)`: Returns the number of members in a struct or union.
+*   `const infix_struct_member* infix_type_get_member(const infix_type* type, size_t index)`: Retrieves a specific member from a struct or union by its index. The returned `infix_struct_member*` gives you access to:
+    *   `.name`: The name of the field as a `const char*`.
+    *   `.type`: The `infix_type*` of the field.
+    *   `.offset`: The field's byte offset from the start of the struct.
+*   `infix_status infix_type_print(...)`: Serializes an `infix_type` back into a human-readable string.
+
+---
+
+## 4. Named Type Registry API
+
+APIs for defining, storing, reusing, and inspecting complex types by name.
+
+### Creation and Population
+
+*   `infix_registry_t* infix_registry_create(void)`: Creates a new, empty type registry.
+*   `void infix_registry_destroy(infix_registry_t* registry)`: Destroys a registry and all its contents.
+*   `infix_status infix_register_types(infix_registry_t* registry, const char* definitions)`: Parses a semicolon-separated string of type definitions and adds them to the registry.
+*   `const infix_type* infix_registry_lookup_type(const infix_registry_t* registry, const char* name)`: Retrieves a fully defined type object by its name.
+
+### Registry Introspection & Iteration
+
+These functions allow you to iterate through all of the fully defined types within a registry.
+
+*   `infix_registry_iterator_t infix_registry_iterator_begin(const infix_registry_t* registry)`: Creates and returns an iterator positioned at the beginning of the registry.
+*   `bool infix_registry_iterator_next(infix_registry_iterator_t* iterator)`: Advances the iterator to the next type. It returns `true` if it successfully moved to a valid type, and `false` if there are no more types to visit.
+*   `const char* infix_registry_iterator_get_name(const infix_registry_iterator_t* iterator)`: Gets the name of the type at the iterator's current position (e.g., `"Point"`).
+*   `const infix_type* infix_registry_iterator_get_type(const infix_registry_iterator_t* iterator)`: Gets the `infix_type` object for the type at the iterator's current position.
+
+---
+
+## 5. Dynamic Library & Globals API
+
+Cross-platform functions for loading shared libraries and accessing exported symbols.
+
+*   `infix_library_t* infix_library_open(const char* path)`: Opens a dynamic library (`.so`, `.dll`).
+*   `void infix_library_close(infix_library_t* lib)`: Closes a library handle.
+*   `void* infix_library_get_symbol(infix_library_t* lib, const char* symbol_name)`: Retrieves the address of a function or global variable.
+*   `infix_status infix_read_global(...)`: Reads the value of a global variable from a library into a buffer.
+*   `infix_status infix_write_global(...)`: Writes data from a buffer into a global variable in a library.
+
+---
+
+## 6. Manual API (Advanced)
+
+A lower-level API for creating trampolines from programmatically-built `infix_type` objects, bypassing the string parser.
+
+### Manual Trampoline Creation
+
+These functions mirror the high-level API but take `infix_type` objects instead of signature strings.
+*   `infix_status infix_forward_create_manual(...)`
+*   `infix_status infix_forward_create_unbound_manual(...)`
+*   `infix_status infix_reverse_create_callback_manual(...)`
+*   `infix_status infix_reverse_create_closure_manual(...)`
+
+### Manual Type Creation
+
+These functions are the building blocks for creating `infix_type` objects programmatically. All new types must be allocated from a user-provided arena.
+
+*   `infix_type* infix_type_create_primitive(infix_primitive_type_id id)`: Returns a static descriptor for a primitive type like `int` or `double`. Does not require an arena.
+*   `infix_type* infix_type_create_pointer(void)`: Returns a static descriptor for a generic `void*`. Does not require an arena.
+*   `infix_type* infix_type_create_void(void)`: Returns the static descriptor for `void`. Does not require an arena.
+*   `infix_status infix_type_create_pointer_to(infix_arena_t* arena, ...)`: Creates a new pointer type that points to a specific other type.
+*   `infix_status infix_type_create_struct(infix_arena_t* arena, ...)`: Creates a new struct, automatically calculating member offsets and padding.
+*   `infix_status infix_type_create_packed_struct(infix_arena_t* arena, ...)`: Creates a struct with a user-specified size, alignment, and member offsets.
+*   `infix_status infix_type_create_union(infix_arena_t* arena, ...)`: Creates a new union, calculating its size and alignment based on its members.
+*   `infix_status infix_type_create_array(infix_arena_t* arena, ...)`: Creates a new fixed-size array type.
+*   `infix_status infix_type_create_enum(infix_arena_t* arena, ...)`: Creates a new enum type with a specified underlying integer type.
+*   `infix_status infix_type_create_complex(infix_arena_t* arena, ...)`: Creates a new C99 `_Complex` number type.
+*   `infix_status infix_type_create_vector(infix_arena_t* arena, ...)`: Creates a new SIMD vector type.
+*   `infix_status infix_type_create_named_reference(infix_arena_t* arena, ...)`: Creates a placeholder for a named type that will be resolved by a registry.
+*   `infix_struct_member infix_type_create_member(...)`: A factory function to create a member object for use with `infix_type_create_struct` or `_union`.
+
+---
+
+## 7. Memory Management (Arenas)
+
+APIs for the fast, region-based arena allocator used by the Manual API.
+
+*   `infix_arena_t* infix_arena_create(size_t initial_size)`: Creates a new memory arena.
+*   `void infix_arena_destroy(infix_arena_t* arena)`: Destroys an arena and frees all memory allocated from it.
+*   `void* infix_arena_alloc(infix_arena_t* arena, size_t size, size_t alignment)`: Allocates a block of memory from an arena.
+*   `void* infix_arena_calloc(infix_arena_t* arena, ...)`: Allocates and zero-initializes memory from an arena.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -106,35 +106,21 @@ This guide provides practical, real-world examples to help you solve common FFI 
 **Solution**: Describe the function's signature, prepare pointers to your arguments, and invoke the function through a generated trampoline. An "unbound" trampoline is ideal when you want to call multiple functions that share the same signature.
 
 ```c
-#include <infix/infix.h>
-#include <math.h>
-#include <stdio.h>
+// 1. Describe the signature: double atan2(double y, double x);
+const char* signature = "(double, double) -> double";
 
-void recipe_simple_forward_call() {
-    // 1. Describe the signature: double atan2(double y, double x);
-    const char* signature = "(double, double) -> double";
+// 2. Create an unbound trampoline.
+infix_forward_t* trampoline = NULL;
+infix_forward_create_unbound(&trampoline, signature, NULL);
 
-    // 2. Create an unbound trampoline. The function to call is not specified yet.
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create_unbound(&trampoline, signature, NULL);
-
-    // 3. Get the callable function pointer.
-    infix_unbound_cif_func cif = infix_forward_get_unbound_code(trampoline);
-
-    // 4. Prepare arguments. The args array must hold *pointers* to the values.
-    double y = 1.0, x = 1.0;
-    void* args[] = { &y, &x };
-    double result;
-
-    // 5. Invoke the call, passing the target function `atan2` as the first argument.
-    cif((void*)atan2, &result, args);
-
-    printf("atan2(1.0, 1.0) = %f (PI/4)\n", result);
-
-    // 6. Clean up.
-    infix_forward_destroy(trampoline);
-}
+// 3. Prepare arguments and invoke the call.
+double y = 1.0, x = 1.0;
+void* args[] = { &y, &x };
+double result;
+infix_forward_get_unbound_code(trampoline)((void*)atan2, &result, args);
 ```
+
+> Full example available in [`Ch01_Rec01_SimpleCall.c`](/eg/cookbook/Ch01_Rec01_SimpleCall.c).
 
 ### Recipe: Passing and Receiving Pointers
 
@@ -143,30 +129,21 @@ void recipe_simple_forward_call() {
 **Solution**: Use the `*` prefix for pointer types. The value in the `args` array for a pointer argument is the address of your pointer variable.
 
 ```c
-#include <infix/infix.h>
-#include <string.h>
-#include <stdio.h>
+// Signature for: const char* strchr(const char* s, int c);
+const char* signature = "(*char, int) -> *char";
+infix_forward_t* trampoline = NULL;
+infix_forward_create(&trampoline, signature, (void*)strchr, NULL);
 
-void recipe_pointer_args_and_return() {
-    // Signature for: const char* strchr(const char* s, int c);
-    const char* signature = "(*char, int) -> *char";
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create(&trampoline, signature, (void*)strchr, NULL);
-    infix_cif_func cif = infix_forward_get_code(trampoline);
+// Prepare arguments. The value for the pointer is the address of the char* variable.
+const char* haystack = "hello-world";
+int needle = '-';
+void* args[] = { &haystack, &needle };
+const char* result_ptr = NULL;
 
-    const char* haystack = "hello-world";
-    int needle = '-';
-    void* args[] = { &haystack, &needle };
-    const char* result_ptr = NULL;
-
-    cif(&result_ptr, args);
-
-    if (result_ptr) {
-        printf("strchr found: '%s'\n", result_ptr); // Expected: "-world"
-    }
-    infix_forward_destroy(trampoline);
-}
+infix_forward_get_code(trampoline)(&result_ptr, args);
 ```
+
+> Full example available in [`Ch01_Rec02_Pointers.c`](/eg/cookbook/Ch01_Rec02_Pointers.c).
 
 ### Recipe: Working with "Out" Parameters
 
@@ -175,47 +152,27 @@ void recipe_pointer_args_and_return() {
 **Solution**: The signature is straightforward. The "out" parameter is simply a pointer type (`*<type>`). In your calling code, you create a local variable and pass its address in the `args` array.
 
 ```c
-// Native C function to be called:
 // bool get_user_stats(int user_id, int* out_posts, double* out_score);
-bool get_user_stats(int user_id, int* out_posts, double* out_score) {
-    if (user_id == 123) {
-        if(out_posts) *out_posts = 50;
-        if(out_score) *out_score = 99.8;
-        return true;
-    }
-    return false;
-}
+const char* signature = "(int, *int, *double) -> bool";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)get_user_stats, NULL);
 
-void recipe_out_parameters() {
-    const char* signature = "(int, *int, *double) -> bool";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)get_user_stats, NULL);
+int user_id = 123;
+// These are our "out" variables.
+int post_count = 0;
+double score = 0.0;
+bool success;
 
-    int user_id = 123;
-    // These are our "out" variables. They will be modified by the C function.
-    int post_count = 0;
-    double score = 0.0;
-    bool success;
+// For "out" parameters, the args array contains pointers TO the pointer variables.
+int* p_post_count = &post_count;
+double* p_score = &score;
+void* args[] = { &user_id, &p_post_count, &p_score };
 
-    int * p_post_count = &post_count;
-    double * p_score = &score;
-
-    // The `args` array contains pointers to our arguments' values.
-    void * args[] = {
-        &user_id,
-        &p_post_count,
-        &p_score
-    };
-
-    infix_forward_get_code(t)(&success, args);
-
-    if (success) {
-        printf("User stats: Posts=%d, Score=%.1f\n", post_count, score); // Expected: 50, 99.8
-    }
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&success, args);
+// After the call, post_count and score are populated.
 ```
+
+> Full example available in [`Ch01_Rec03_OutParameters.c`](/eg/cookbook/Ch01_Rec03_OutParameters.c).
 
 ### Recipe: Working with Opaque Pointers (Incomplete Types)
 
@@ -224,40 +181,24 @@ void recipe_out_parameters() {
 **Solution**: Use the `*void` signature. This is the canonical representation for any generic handle. Using a registry to create a type alias like `@FileHandle = *void;` can make your signatures more readable.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
+// 1. Use a registry to create a readable alias for the opaque handle.
+infix_registry_t* reg = infix_registry_create();
+infix_register_types(reg, "@FileHandle = *void;");
 
-void recipe_opaque_pointers() {
-    infix_registry_t* reg = infix_registry_create();
-    infix_register_types(reg, "@FileHandle = *void;");
+// 2. Create trampolines using the alias.
+infix_forward_t *t_fopen, *t_fputs, *t_fclose;
+infix_forward_create(&t_fopen, "(*char, *char) -> @FileHandle", (void*)fopen, reg);
+infix_forward_create(&t_fputs, "(*char, @FileHandle) -> int", (void*)fputs, reg);
+infix_forward_create(&t_fclose, "(@FileHandle) -> int", (void*)fclose, reg);
 
-    infix_forward_t *t_fopen, *t_fputs, *t_fclose;
-    infix_forward_create(&t_fopen, "(*char, *char) -> @FileHandle", (void*)fopen, reg);
-    infix_forward_create(&t_fputs, "(*char, @FileHandle) -> int", (void*)fputs, reg);
-    infix_forward_create(&t_fclose, "(@FileHandle) -> int", (void*)fclose, reg);
-
-    void* file_handle = NULL; // This will hold our opaque FILE*
-    const char* filename = "test.txt";
-    const char* mode = "w";
-    void* fopen_args[] = { &filename, &mode };
-
-    infix_forward_get_code(t_fopen)(&file_handle, fopen_args);
-
-    if (file_handle) {
-        const char* content = "Written by infix!";
-        void* fputs_args[] = { &content, &file_handle };
-        int result;
-        infix_forward_get_code(t_fputs)(&result, fputs_args);
-        infix_forward_get_code(t_fclose)(&result, &file_handle);
-        printf("Successfully wrote to test.txt\n");
-    }
-
-    infix_forward_destroy(t_fopen);
-    infix_forward_destroy(t_fputs);
-    infix_forward_destroy(t_fclose);
-    infix_registry_destroy(reg);
-}
+// 3. Use the trampolines in sequence.
+void* file_handle = NULL; // This will hold our opaque FILE*
+const char* filename = "test.txt", *mode = "w";
+infix_forward_get_code(t_fopen)(&file_handle, (void*[]){ &filename, &mode });
+// ...
 ```
+
+> Full example available in [`Ch01_Rec04_OpaquePointers.c`](/eg/cookbook/Ch01_Rec04_OpaquePointers.c).
 
 ---
 
@@ -269,28 +210,25 @@ typedef struct { double x, y; } Point;
 ```
 
 ### Recipe: Small Structs Passed by Value
+
 **Problem**: You need to call a function that takes a small `struct` that the ABI passes in registers.
 **Solution**: Use the struct syntax `({...})`. `infix` will automatically determine the correct ABI passing convention for the target platform.
 
 ```c
-Point move_point(Point p, double dx) { p.x += dx; return p; }
+// Point move_point(Point p, double dx);
+const char* signature = "({double, double}, double) -> {double, double}";
+infix_forward_t* trampoline = NULL;
+infix_forward_create(&trampoline, signature, (void*)move_point, NULL);
 
-void recipe_pass_struct_by_value() {
-    const char* signature = "({double, double}, double) -> {double, double}";
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create(&trampoline, signature, (void*)move_point, NULL);
+Point start = { 10.0, 20.0 };
+double delta_x = 5.5;
+void* args[] = { &start, &delta_x };
+Point end;
 
-    Point start = { 10.0, 20.0 };
-    double delta_x = 5.5;
-    void* args[] = { &start, &delta_x };
-    Point end;
-
-    infix_forward_get_code(trampoline)(&end, args);
-    printf("Moved point has x = %f\n", end.x); // Should be 15.5
-
-    infix_forward_destroy(trampoline);
-}
+infix_forward_get_code(trampoline)(&end, args);
 ```
+
+> Full example available in [`Ch02_Rec01_StructByValue.c`](/eg/cookbook/Ch02_Rec01_StructByValue.c).
 
 ### Recipe: Receiving a Struct from a Function
 
@@ -299,23 +237,19 @@ void recipe_pass_struct_by_value() {
 **Solution**: `infix` handles the ABI details, whether the struct is returned in registers or via a hidden pointer passed by the caller.
 
 ```c
-Point make_point(double x, double y) { return (Point){x, y}; }
+// Point make_point(double x, double y);
+const char* signature = "(double, double) -> {double, double}";
+infix_forward_t* trampoline = NULL;
+infix_forward_create(&trampoline, signature, (void*)make_point, NULL);
 
-void recipe_return_struct() {
-    const char* signature = "(double, double) -> {double, double}";
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create(&trampoline, signature, (void*)make_point, NULL);
+double x = 100.0, y = 200.0;
+void* args[] = { &x, &y };
+Point result;
 
-    double x = 100.0, y = 200.0;
-    void* args[] = { &x, &y };
-    Point result;
-
-    infix_forward_get_code(trampoline)(&result, args);
-    printf("Received point: {x=%.1f, y=%.1f}\n", result.x, result.y);
-
-    infix_forward_destroy(trampoline);
-}
+infix_forward_get_code(trampoline)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec02_ReturnStruct.c`](/eg/cookbook/Ch02_Rec02_ReturnStruct.c).
 
 ### Recipe: Large Structs Passed by Reference
 
@@ -324,24 +258,19 @@ void recipe_return_struct() {
 **Solution**: The process is identical to the small struct example. `infix`'s ABI logic will detect that the struct is large and automatically pass it by reference (the standard C ABI rule).
 
 ```c
-typedef struct { int data[8]; } LargeStruct;
-int get_first_element(LargeStruct s) { return s.data[0]; }
+// int get_first_element(LargeStruct s); where LargeStruct is { int data[8]; }
+const char* signature = "({[8:int]}) -> int";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)get_first_element, NULL);
 
-void recipe_large_struct() {
-    const char* signature = "({[8:int]}) -> int";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)get_first_element, NULL);
+LargeStruct my_struct = { {123, -1, -1, -1, -1, -1, -1, -1} };
+void* args[] = { &my_struct };
+int result;
 
-    LargeStruct my_struct = { {123, -1, -1, -1, -1, -1, -1, -1} };
-    void* args[] = { &my_struct };
-    int result;
-
-    infix_forward_get_code(t)(&result, args);
-    printf("First element of large struct: %d\n", result); // Should be 123
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec03_LargeStruct.c`](/eg/cookbook/Ch02_Rec03_LargeStruct.c).
 
 ### Recipe: Working with Packed Structs
 
@@ -350,26 +279,19 @@ void recipe_large_struct() {
 **Solution**: Use the `!{...}` syntax for 1-byte alignment, or `!N:{...}` to specify a maximum alignment of `N` bytes.
 
 ```c
-#pragma pack(push, 1)
-typedef struct { char a; uint64_t b; } Packed; // Total size is 9 bytes
-#pragma pack(pop)
+// int process_packed(Packed p); where Packed is #pragma pack(1) { char a; uint64_t b; }
+const char* signature = "(!{char, uint64}) -> int";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)process_packed, NULL);
 
-int process_packed(Packed p) { return (p.a == 'X' && p.b == 0x1122334455667788ULL) ? 42 : -1; }
+Packed p = {'X', 0x1122334455667788ULL};
+int result = 0;
+void* args[] = {&p};
 
-void recipe_packed_struct() {
-    const char* signature = "(!{char, uint64}) -> int";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)process_packed, NULL);
-
-    Packed p = {'X', 0x1122334455667788ULL};
-    int result = 0;
-    void* args[] = {&p};
-
-    infix_forward_get_code(t)(&result, args);
-    printf("Packed struct result: %d\n", result);  // Expected: 42
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec04_PackedStructs.c`](/eg/cookbook/Ch02_Rec04_PackedStructs.c).
 
 ### Recipe: Working with Structs that Contain Bitfields
 
@@ -378,40 +300,25 @@ void recipe_packed_struct() {
 **Solution**: Treat the underlying integer that holds the bitfields as a single member in your signature. Then, use C's bitwise operators in your wrapper code to manually pack and unpack the values before and after the FFI call.
 
 ```c
-// The native C struct with bitfields.
-typedef struct {
-    uint32_t a : 4; // 4 bits
-    uint32_t b : 12;// 12 bits
-    uint32_t c : 16;// 16 bits
-} BitfieldStruct; // Total size is sizeof(uint32_t)
+// uint32_t process_bitfields(BitfieldStruct s);
+// 1. Describe the struct by its underlying integer storage.
+const char* signature = "({uint32}) -> uint32";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)process_bitfields, NULL);
 
-// The native function we want to call.
-uint32_t process_bitfields(BitfieldStruct s) {
-    return s.a + s.b + s.c;
-}
+// 2. Manually pack the data into a uint32_t.
+uint32_t packed_data = 0;
+packed_data |= (15 & 0xF) << 0;      // Field a = 15
+packed_data |= (1000 & 0xFFF) << 4;  // Field b = 1000
+packed_data |= (30000 & 0xFFFF) << 16; // Field c = 30000
 
-void recipe_bitfields() {
-    // 1. Describe the struct by its underlying integer storage.
-    const char* signature = "({uint32}) -> uint32";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)process_bitfields, NULL);
-
-    // 2. Manually pack the data into a uint32_t.
-    uint32_t packed_data = 0;
-    packed_data |= (15 & 0xF) << 0;  // Field a = 15
-    packed_data |= (1000 & 0xFFF) << 4; // Field b = 1000
-    packed_data |= (30000 & 0xFFFF) << 16; // Field c = 30000
-
-    // 3. The FFI call sees a simple struct { uint32_t; }.
-    void* args[] = { &packed_data };
-    uint32_t result;
-
-    infix_forward_get_code(t)(&result, args);
-    printf("Bitfield sum: %u\n", result); // Expected: 31015
-
-    infix_forward_destroy(t);
-}
+// 3. The FFI call sees a simple struct { uint32_t; }.
+void* args[] = { &packed_data };
+uint32_t result;
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec05_Bitfields.c`](/eg/cookbook/Ch02_Rec05_Bitfields.c).
 
 ### Recipe: Working with Unions
 
@@ -420,25 +327,20 @@ void recipe_bitfields() {
 **Solution**: Use the `<...>` syntax to describe the union's members.
 
 ```c
-typedef union { int i; float f; } Number;
-int process_number_as_int(Number n) { return n.i * 2; }
+// int process_number_as_int(Number n); where Number is union { int i; float f; }
+const char* signature = "(<int, float>) -> int";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)process_number_as_int, NULL);
 
-void recipe_union() {
-    const char* signature = "(<int, float>) -> int";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)process_number_as_int, NULL);
+Number num_val;
+num_val.i = 21;
+int result = 0;
+void* args[] = {&num_val};
 
-    Number num_val;
-    num_val.i = 21;
-    int result = 0;
-    void* args[] = {&num_val};
-
-    infix_forward_get_code(t)(&result, args);
-    printf("Result: %d\n", result);  // Expected: 42
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec06_Unions.c`](/eg/cookbook/Ch02_Rec06_Unions.c).
 
 ### Recipe: Working with Fixed-Size Arrays
 
@@ -447,30 +349,22 @@ void recipe_union() {
 **Solution**: In C, an array argument "decays" to a pointer to its first element. The signature must reflect this. To describe the array *itself* (e.g., inside a struct), use the `[N:type]` syntax.
 
 ```c
-// In C, a function parameter `arr[4]` is treated as a pointer `arr*`.
-int64_t sum_array_elements(const int64_t* arr, size_t count) {
-    int64_t sum = 0;
-    for(size_t i = 0; i < count; ++i) sum += arr[i];
-    return sum;
-}
+// int64_t sum_array_elements(const int64_t* arr, size_t count);
+// Note: Even if the C prototype was `arr[4]`, it decays to a pointer.
+const char* signature = "(*sint64, size_t) -> sint64";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)sum_array_elements, NULL);
 
-void recipe_array_decay() {
-    const char* signature = "(*sint64, sint64) -> sint64";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)sum_array_elements, NULL);
+int64_t my_array[] = {10, 20, 30, 40};
+const int64_t* ptr_to_array = my_array;
+size_t count = 4;
+void* args[] = {&ptr_to_array, &count};
+int64_t result = 0;
 
-    int64_t my_array[] = {10, 20, 30, 40};
-    const int64_t* ptr_to_array = my_array;
-    int64_t count = 4; // Using int64_t for sint64 signature
-    void* args[] = {&ptr_to_array, &count};
-    int64_t result = 0;
-
-    infix_forward_get_code(t)(&result, args);
-    printf("Sum of array is: %lld\n", (long long)result);  // Expected: 100
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec07_ArrayDecay.c`](/eg/cookbook/Ch02_Rec07_ArrayDecay.c).
 
 ### Recipe: Advanced Named Types (Recursive & Forward-Declared)
 
@@ -479,59 +373,31 @@ void recipe_array_decay() {
 **Solution**: The `infix` registry fully supports recursive definitions and forward declarations, allowing you to model these patterns cleanly.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
+infix_registry_t* registry = infix_registry_create();
 
-// C equivalent of the types we will define:
-typedef struct Employee Employee;
-typedef struct Manager {
-    const char* name;
-    Employee* reports[10]; // A manager has direct reports
-} Manager;
+// 1. Define types using forward declarations for mutual recursion.
+const char* definitions =
+    "@Employee; @Manager;" // Forward declarations
+    "@Manager = { name:*char, reports:[10:*@Employee] };"
+    "@Employee = { name:*char, manager:*@Manager };"
+;
+infix_register_types(registry, definitions);
 
-struct Employee {
-    const char* name;
-    Manager* manager; // An employee has a manager
-};
+// 2. Create a trampoline using the named types.
+infix_forward_t* trampoline = NULL;
+infix_forward_create(&trampoline, "(*@Employee) -> *char", (void*)get_manager_name, registry);
 
-// A simple function to demonstrate usage
-const char* get_manager_name(Employee* e) {
-    return e->manager ? e->manager->name : "None";
-}
+// 3. Set up the C data and call.
+Manager boss = { "Sanko", { NULL } };
+Employee worker = { "Robinson", &boss };
+Employee* p_worker = &worker;
+const char* manager_name = NULL;
+void* args[] = { &p_worker };
 
-void recipe_advanced_registry() {
-    infix_registry_t* registry = infix_registry_create();
-
-    // 1. Define the types. Note the forward declarations with a single ';'.
-    //    This is necessary because Manager refers to Employee, and Employee
-    //    refers to Manager.
-    const char* definitions =
-        "@Employee; @Manager;" // Forward declarations
-        "@Manager = { name:*char, reports:[10:*@Employee] };"
-        "@Employee = { name:*char, manager:*@Manager };"
-    ;
-    infix_register_types(registry, definitions);
-
-    // 2. Create a trampoline using the named types.
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create(&trampoline, "(*@Employee) -> *char", (void*)get_manager_name, registry);
-
-    // 3. Set up the C data and call.
-    Manager boss = { "Sanko", { NULL } };
-    Employee worker = { "Robinson", &boss };
-    Employee* p_worker = &worker;
-    const char* manager_name = NULL;
-    void* args[] = { &p_worker };
-
-    infix_forward_get_code(trampoline)(&manager_name, args);
-
-    printf("The manager of %s is %s.\n", worker.name, manager_name); // Expected: Sanko
-
-    // 4. Clean up.
-    infix_forward_destroy(trampoline);
-    infix_registry_destroy(registry);
-}
+infix_forward_get_code(trampoline)(&manager_name, args);
 ```
+
+> Full example available in [`Ch02_Rec08_AdvancedRegistry.c`](/eg/cookbook/Ch02_Rec08_AdvancedRegistry.c).
 
 ### Recipe: Working with Complex Numbers
 
@@ -540,24 +406,19 @@ void recipe_advanced_registry() {
 **Solution**: Use the `c[<base_type>]` constructor in the signature string.
 
 ```c
-#include <complex.h>
-double complex c_square(double complex z) { return z * z; }
+// double complex c_square(double complex z);
+const char* signature = "(c[double]) -> c[double]";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)c_square, NULL);
 
-void recipe_complex() {
-    const char* signature = "(c[double]) -> c[double]";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)c_square, NULL);
+double complex input = 3.0 + 4.0 * I;
+double complex result;
+void* args[] = {&input};
 
-    double complex input = 3.0 + 4.0 * I;
-    double complex result;
-    void* args[] = {&input};
-
-    infix_forward_get_code(t)(&result, args);
-    printf("The square of (3.0 + 4.0i) is (%.1f + %.1fi)\n", creal(result), cimag(result));
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec09_ComplexNumbers.c`](/eg/cookbook/Ch02_Rec09_ComplexNumbers.c).
 
 ### Recipe: Working with SIMD Vectors
 
@@ -574,38 +435,22 @@ This recipe is broken down by architecture, as the C types and intrinsic functio
 This example calls a function that uses AVX-512's 512-bit `__m512d` type to add two vectors of eight `double`s each. The same principle applies to 128-bit SSE (`__m128d`) and 256-bit AVX (`__m256d`) types by simply adjusting the signature.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <immintrin.h> // For AVX-512 intrinsics
+// __m512d vector_add_512(__m512d a, __m512d b);
+// The signature "m512d" is a convenient alias for "v[8:double]".
+const char* signature = "(m512d, m512d) -> m512d";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)vector_add_512, NULL);
 
-// Native C function using AVX-512 vectors
-__m512d vector_add_512(__m512d a, __m512d b) { return _mm512_add_pd(a, b); }
+// Prepare arguments using AVX-512 intrinsics.
+__m512d a = _mm512_set_pd(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+__m512d b = _mm512_set_pd(34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0, 41.0);
+void* args[] = {&a, &b};
+__m512d result;
 
-void recipe_simd_avx512() {
-    // The signature "m512d" is a convenient alias for "v[8:double]".
-    const char* signature = "(m512d, m512d) -> m512d";
-    infix_forward_t* t = NULL;
-    // Note: This test must be compiled with AVX-512 support (e.g., -mavx512f)
-    // and run on a CPU that supports it to avoid a crash.
-    infix_forward_create(&t, signature, (void*)vector_add_512, NULL);
-
-    // Prepare arguments using AVX-512 intrinsics.
-    // _mm512_set_pd sets values from right-to-left in memory.
-    __m512d a = _mm512_set_pd(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
-    __m512d b = _mm512_set_pd(34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0, 41.0);
-    void* args[] = {&a, &b};
-    __m512d result;
-
-    infix_forward_get_code(t)(&result, args);
-
-    // Unpack the result for verification.
-    double* d = (double*)&result;
-    printf("AVX-512 vector result: [%.1f, %.1f, ..., %.1f, %.1f]\n", d[0], d[1], d[6], d[7]);
-    // Expected: {1+41, 2+40, ..., 8+34} -> {42.0, 42.0, ..., 42.0, 42.0}
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec10_SIMD_AVX.c`](/eg/cookbook/Ch02_Rec10_SIMD_AVX.c).
 
 ---
 
@@ -614,34 +459,22 @@ void recipe_simd_avx512() {
 This example calls a function that uses ARM NEON's `float32x4_t` type, which is a 128-bit vector of four `float`s.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <arm_neon.h> // For NEON intrinsics
+// float neon_horizontal_sum(float32x4_t vec);
+// The signature v[4:float] directly maps to float32x4_t.
+const char* signature = "(v[4:float]) -> float";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)neon_horizontal_sum, NULL);
 
-// Native C function that performs a horizontal add on a NEON vector.
-float neon_horizontal_sum(float32x4_t vec) {
-    return vaddvq_f32(vec); // Adds all four elements in the vector together.
-}
+// Prepare the NEON vector argument.
+float data[] = {10.0f, 20.0f, 5.5f, 6.5f};
+float32x4_t input_vec = vld1q_f32(data); // Load data into a vector register.
+void* args[] = {&input_vec};
+float result;
 
-void recipe_simd_neon() {
-    // The signature v[4:float] directly maps to float32x4_t.
-    const char* signature = "(v[4:float]) -> float";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)neon_horizontal_sum, NULL);
-
-    // Prepare the NEON vector argument.
-    float data[] = {10.0f, 20.0f, 5.5f, 6.5f};
-    float32x4_t input_vec = vld1q_f32(data); // Load data into a vector register.
-    void* args[] = {&input_vec};
-    float result;
-
-    infix_forward_get_code(t)(&result, args);
-
-    printf("NEON horizontal sum result: %.1f\n", result); // Expected: 42.0
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch02_Rec10_SIMD_NEON.c`](/eg/cookbook/Ch02_Rec10_SIMD_NEON.c).
 
 ---
 
@@ -652,83 +485,28 @@ void recipe_simd_neon() {
 **Solution**: This requires a dynamic, multi-step approach. You must first perform a runtime check for SVE support, then query the CPU's vector length, and finally build the `infix` signature string dynamically before creating the trampoline.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <stdbool.h>
+// double sve_horizontal_add(svfloat64_t vec);
 
-#if defined(__ARM_FEATURE_SVE)
-#include <arm_sve.h>
-// Platform-specific headers for runtime detection
-#if defined(__linux__)
-#include <sys/auxv.h>
-#ifndef HWCAP_SVE
-#define HWCAP_SVE (1 << 22)
-#endif
-#elif defined(__APPLE__)
-#include <sys/sysctl.h>
-#endif
+// 1. Query the vector length at runtime. svcntd() gets the count of doubles.
+size_t num_doubles = svcntd();
 
-// Helper function to check for SVE support at runtime.
-static bool is_sve_supported(void) {
-#if defined(__linux__)
-    return (getauxval(AT_HWCAP) & HWCAP_SVE) != 0;
-#elif defined(__APPLE__)
-    int sve_present = 0; size_t size = sizeof(sve_present);
-    if (sysctlbyname("hw.optional.arm.FEAT_SVE", &sve_present, &size, NULL, 0) == 0)
-        return sve_present == 1;
-    return false;
-#else // Windows, etc. would have their own checks.
-    return false;
-#endif
-}
+// 2. Build the signature string dynamically.
+char signature[64];
+snprintf(signature, sizeof(signature), "(v[%zu:double]) -> double", num_doubles);
 
-// Native C function using SVE for a horizontal add.
-double sve_horizontal_add(svfloat64_t vec) { return svaddv_f64(svptrue_b64(), vec); }
+// 3. Create the trampoline with the dynamic signature.
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)sve_horizontal_add, NULL);
 
-void recipe_simd_sve() {
-    if (!is_sve_supported()) {
-        printf("SVE not supported on this CPU, skipping recipe.\n");
-        return;
-    }
-
-    // 1. Query the vector length at runtime. svcntd() gets the count of doubles.
-    size_t num_doubles = svcntd();
-    printf("Detected SVE vector length: %zu doubles (%zu bits)\n", num_doubles, num_doubles * 64);
-
-    // 2. Build the signature string dynamically.
-    char signature[64];
-    snprintf(signature, sizeof(signature), "(v[%zu:double]) -> double", num_doubles);
-    printf("Generated signature: %s\n", signature);
-
-    // 3. Create the trampoline with the dynamic signature.
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)sve_horizontal_add, NULL);
-
-    // 4. Prepare arguments and call.
-    double* data = (double*)malloc(sizeof(double) * num_doubles);
-    for (size_t i = 0; i < num_doubles; ++i)
-        data[i] = (i == 0) ? 42.0 : 0.0; // Put 42 in the first lane.
-
-    svbool_t pg = svptrue_b64();
-    svfloat64_t input_vec = svld1_f64(pg, data);
-    void* args[] = {&input_vec};
-    double result;
-
-    infix_forward_get_code(t)(&result, args);
-
-    printf("SVE horizontal sum result: %.1f\n", result); // Expected: 42.0
-
-    // 5. Clean up.
-    free(data);
-    infix_forward_destroy(t);
-}
-
-#else // If not compiled with SVE support
-void recipe_simd_sve() {
-    printf("SVE recipe skipped: not compiled with SVE support (e.g., -march=armv8-a+sve).\n");
-}
-#endif
+// 4. Prepare arguments and call.
+double* data = (double*)malloc(sizeof(double) * num_doubles);
+// ... populate data ...
+svfloat64_t input_vec = svld1_f64(svptrue_b64(), data);
+double result;
+infix_forward_get_code(t)(&result, (void*[]){&input_vec});
 ```
+
+> Full example available in [`Ch02_Rec10_SIMD_SVE.c`](/eg/cookbook/Ch02_Rec10_SIMD_SVE.c).
 
 ### Recipe: Working with Enums
 
@@ -737,35 +515,21 @@ void recipe_simd_sve() {
 **Solution**: Use the `e:<type>` syntax in the signature string. `infix` treats the enum identically to its underlying integer type for the FFI call, which is the correct behavior.
 
 ```c
-// Native C enum and function
-typedef enum { STATUS_OK = 0, STATUS_WARN = 1, STATUS_ERR = -1 } StatusCode;
-const char* status_to_string(StatusCode code) {
-    switch (code) {
-        case STATUS_OK:   return "OK";
-        case STATUS_WARN: return "Warning";
-        case STATUS_ERR:  return "Error";
-        default:          return "Unknown";
-    }
-}
+// const char* status_to_string(StatusCode code);
+// The C `enum` is based on `int`, so we describe it as `e:int`.
+const char* signature = "(e:int) -> *char";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)status_to_string, NULL);
 
-void recipe_enums() {
-    // The C `enum` is based on `int`, so we describe it as `e:int`.
-    const char* signature = "(e:int) -> *char";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)status_to_string, NULL);
+// Pass the enum value as its underlying integer type.
+int code = STATUS_ERR;
+const char* result_str = NULL;
+void* args[] = { &code };
 
-    // Pass the enum value as its underlying integer type.
-    int code = STATUS_ERR;
-    const char* result_str = NULL;
-    void* args[] = { &code };
-
-    infix_forward_get_code(t)(&result_str, args);
-
-    printf("Status for code %d is '%s'\n", code, result_str); // Expected: 'Error'
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result_str, args);
 ```
+
+> Full example available in [`Ch02_Rec11_Enums.c`](/eg/cookbook/Ch02_Rec11_Enums.c).
 
 ---
 
@@ -778,37 +542,25 @@ void recipe_enums() {
 **Solution**: Use `infix_reverse_create_callback`. The handler is a normal, clean C function whose signature exactly matches what `qsort` expects.
 
 ```c
-#include <stdlib.h>
-
-// 1. The handler function has a standard C signature. No context pointer is needed.
+// 1. The handler function has a standard C signature.
 int compare_integers_handler(const void* a, const void* b) {
     return (*(const int*)a - *(const int*)b);
 }
 
-void recipe_qsort_callback() {
-    // 2. Create the reverse trampoline.
-    infix_reverse_t* context = NULL;
-    const char* cmp_sig = "(*void, *void) -> int";
-    infix_reverse_create_callback(&context, cmp_sig, (void*)compare_integers_handler, NULL);
+// 2. Create the reverse trampoline.
+const char* cmp_sig = "(*void, *void) -> int";
+infix_reverse_t* context = NULL;
+infix_reverse_create_callback(&context, cmp_sig, (void*)compare_integers_handler, NULL);
 
-    // 3. Get the native function pointer.
-    typedef int (*compare_func_t)(const void*, const void*);
-    compare_func_t my_comparator = (compare_func_t)infix_reverse_get_code(context);
+// 3. Get the native function pointer and pass it to qsort.
+typedef int (*compare_func_t)(const void*, const void*);
+compare_func_t my_comparator = (compare_func_t)infix_reverse_get_code(context);
 
-    // 4. Use the generated callback with the C library function.
-    int numbers[] = { 5, 1, 4, 2, 3 };
-    size_t num_count = sizeof(numbers) / sizeof(numbers[0]);
-    qsort(numbers, num_count, sizeof(int), my_comparator);
-
-    printf("Sorted numbers:");
-    for(size_t i = 0; i < num_count; ++i) {
-        printf(" %d", numbers[i]);
-    }
-    printf("\n");
-
-    infix_reverse_destroy(context);
-}
+int numbers[] = { 5, 1, 4, 2, 3 };
+qsort(numbers, 5, sizeof(int), my_comparator);
 ```
+
+> Full example available in [`Ch03_Rec01_QsortCallback.c`](/eg/cookbook/Ch03_Rec01_QsortCallback.c).
 
 ### Recipe: Creating a Stateful Callback
 
@@ -817,44 +569,25 @@ void recipe_qsort_callback() {
 **Solution**: Use `infix_reverse_create_closure`. This API is specifically designed for stateful callbacks. You provide a generic handler and a `void* user_data` pointer to your state. Inside the handler, you can retrieve this pointer from the `context`.
 
 ```c
-typedef struct { const char * name; int sum; } AppContext;
-
-// 1. The handler for a closure has a generic signature.
+// 1. The generic handler retrieves state from the context's user_data field.
 void my_stateful_handler(infix_context_t* context, void* ret, void** args) {
-    (void)ret; // This handler doesn't return a value.
-
-    // 2. Retrieve your state from the context's user_data field.
     AppContext* ctx = (AppContext*)infix_reverse_get_user_data(context);
-
-    // 3. Manually unbox the arguments from the void** array.
     int item_value = *(int*)args[0];
-
     ctx->sum += item_value;
 }
 
-// A C library function that takes a callback but no user_data.
-typedef void (*item_processor_t)(int);
-void process_list(const int* items, int count, item_processor_t process_func) {
-    for (int i = 0; i < count; ++i) process_func(items[i]);
-}
+// 2. Prepare your state and create the closure, passing a pointer to the state.
+AppContext ctx = {"My List", 0};
+infix_reverse_t* rt = NULL;
+infix_reverse_create_closure(&rt, "(int) -> void", my_stateful_handler, &ctx, NULL);
 
-void recipe_stateful_callback() {
-    // a. Prepare your state.
-    AppContext ctx = {"My List", 0};
-
-    // b. Create the closure, passing a pointer to your state as user_data.
-    infix_reverse_t* rt = NULL;
-    infix_reverse_create_closure(&rt, "(int) -> void", my_stateful_handler, &ctx, NULL);
-
-    // c. Use the generated callback.
-    item_processor_t processor_ptr = (item_processor_t)infix_reverse_get_code(rt);
-    int list[] = {10, 20, 30};
-    process_list(list, 3, processor_ptr);
-    printf("Final sum for '%s': %d\n", ctx.name, ctx.sum);  // Expected: 60
-
-    infix_reverse_destroy(rt);
-}
+// 3. Use the generated callback with a C library function.
+item_processor_t processor_ptr = (item_processor_t)infix_reverse_get_code(rt);
+int list[] = {10, 20, 30};
+process_list(list, 3, processor_ptr);
 ```
+
+> Full example available in [`Ch03_Rec02_StatefulCallback.c`](/eg/cookbook/Ch03_Rec02_StatefulCallback.c).
 
 ---
 
@@ -867,21 +600,21 @@ void recipe_stateful_callback() {
 **Solution**: Use the `;` token to separate fixed and variadic arguments. The signature must exactly match the types you are passing in a *specific call*.
 
 ```c
-void recipe_variadic_printf() {
-    const char* signature = "(*char; int, double) -> int";
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create(&trampoline, signature, (void*)printf, NULL);
+// Signature for: printf(const char* format, int arg1, double arg2);
+const char* signature = "(*char; int, double) -> int";
+infix_forward_t* trampoline = NULL;
+infix_forward_create(&trampoline, signature, (void*)printf, NULL);
 
-    const char* fmt = "Count: %d, Value: %.2f\n";
-    int count = 42;
-    double value = 123.45;
-    void* args[] = { &fmt, &count, &value };
-    int result;
+const char* fmt = "Count: %d, Value: %.2f\n";
+int count = 42;
+double value = 123.45;
+void* args[] = { &fmt, &count, &value };
+int result;
 
-    infix_forward_get_code(trampoline)(&result, args);
-    infix_forward_destroy(trampoline);
-}
+infix_forward_get_code(trampoline)(&result, args);
 ```
+
+> Full example available in [`Ch04_Rec01_VariadicPrintf.c`](/eg/cookbook/Ch04_Rec01_VariadicPrintf.c).
 
 ### Recipe: Receiving and Calling a Function Pointer
 
@@ -890,28 +623,27 @@ void recipe_variadic_printf() {
 **Solution**: The signature for a function pointer is `*((...) -> ...)`. Generate your callback, get its native pointer, and pass that pointer as an argument.
 
 ```c
+// 1. Create the inner callback.
 int multiply_handler(int x) { return x * 10; }
-int harness_func(int (*worker_func)(int), int base_val) { return worker_func(base_val); }
+infix_reverse_t* inner_cb_ctx = NULL;
+infix_reverse_create_callback(&inner_cb_ctx, "(int)->int", (void*)multiply_handler, NULL);
 
-void recipe_callback_as_arg() {
-    infix_reverse_t* inner_cb_ctx = NULL;
-    infix_reverse_create_callback(&inner_cb_ctx, "(int)->int", (void*)multiply_handler, NULL);
+// 2. Create the outer trampoline for the function that *takes* the callback.
+//    Signature for: int harness_func( int(*)(int), int );
+const char* harness_sig = "(*((int)->int), int) -> int";
+infix_forward_t* harness_trampoline = NULL;
+infix_forward_create(&harness_trampoline, harness_sig, (void*)harness_func, NULL);
 
-    infix_forward_t* harness_trampoline = NULL;
-    infix_forward_create(&harness_trampoline, "(*((int)->int), int) -> int", (void*)harness_func, NULL);
+// 3. Get the native pointer from the callback and pass it as an argument.
+void* inner_cb_ptr = infix_reverse_get_code(inner_cb_ctx);
+int value = 7;
+void* harness_args[] = { &inner_cb_ptr, &value };
+int result;
 
-    void* inner_cb_ptr = infix_reverse_get_code(inner_cb_ctx);
-    int value = 7;
-    void* harness_args[] = { &inner_cb_ptr, &value };
-    int result;
-
-    infix_forward_get_code(harness_trampoline)(&result, harness_args);
-    printf("Result from nested callback: %d\n", result); // Should be 70
-
-    infix_forward_destroy(harness_trampoline);
-    infix_reverse_destroy(inner_cb_ctx);
-}
+infix_forward_get_code(harness_trampoline)(&result, harness_args);
 ```
+
+> Full example available in [`Ch04_Rec02_CallbackAsArg.c`](/eg/cookbook/Ch04_Rec02_CallbackAsArg.c).
 
 ### Recipe: Calling a Function Pointer from a Struct (V-Table Emulation)
 
@@ -920,52 +652,31 @@ void recipe_callback_as_arg() {
 **Solution**: This is a two-step FFI process. First, read the function pointer value from the struct. Second, create a new trampoline for that function pointer's signature and call it. The Type Registry is perfect for making this clean.
 
 ```c
-// C equivalent of a simple "object" with a v-table.
-typedef struct { int val; } Adder;
-int vtable_add(Adder* self, int amount) { return self->val + amount; }
-void vtable_destroy(Adder* self) { free(self); }
+// 1. Define types for the object, function pointers, and v-table.
+infix_registry_t* reg = infix_registry_create();
+infix_register_types(reg,
+    "@Adder = { val: int };"
+    "@Adder_add_fn = (*@Adder, int) -> int;"
+    "@AdderVTable = { add: *@Adder_add_fn };"
+);
 
-typedef struct {
-    int (*add)(Adder* self, int amount);
-    void (*destroy)(Adder* self);
-} AdderVTable;
+// 2. Create an object and get a pointer to its v-table.
+Adder* my_adder = create_adder(100);
+const AdderVTable* vtable = &VTABLE;
 
-const AdderVTable VTABLE = { vtable_add, vtable_destroy };
-Adder* create_adder(int base) {
-    Adder* a = malloc(sizeof(Adder));
-    if (a) a->val = base;
-    return a;
-}
+// 3. Read the function pointer from the v-table.
+void* add_func_ptr = (void*)vtable->add;
 
-void recipe_vtable_call() {
-    infix_registry_t* reg = infix_registry_create();
-    infix_register_types(reg,
-        "@Adder = { val: int };"
-        "@Adder_add_fn = (*@Adder, int) -> int;"
-        "@AdderVTable = { add: *@Adder_add_fn };" // Only need to describe the one we're calling
-    );
+// 4. Create a trampoline for the specific function pointer and call it.
+infix_forward_t* t_add = NULL;
+infix_forward_create(&t_add, "@Adder_add_fn", add_func_ptr, reg);
 
-    Adder* my_adder = create_adder(100);
-    const AdderVTable* vtable = &VTABLE;
-
-    void* add_func_ptr = (void*)vtable->add;
-
-    infix_forward_t* t_add = NULL;
-    // Note: The signature here must match the member we are calling.
-    infix_forward_create(&t_add, "(*@Adder, int) -> int", add_func_ptr, reg);
-
-    int amount_to_add = 23;
-    int result;
-    void* add_args[] = { &my_adder, &amount_to_add };
-    infix_forward_get_code(t_add)(&result, add_args);
-
-    printf("Result from v-table call: %d\n", result); // Expected: 123
-
-    infix_forward_destroy(t_add);
-    infix_registry_destroy(reg);
-    free(my_adder);
-}
+int amount_to_add = 23, result;
+void* add_args[] = { &my_adder, &amount_to_add };
+infix_forward_get_code(t_add)(&result, add_args);
 ```
+
+> Full example available in [`Ch04_Rec03_VTableCStyle.c`](/eg/cookbook/Ch04_Rec03_VTableCStyle.c).
 
 ### Recipe: Handling `longdouble`
 
@@ -974,33 +685,20 @@ void recipe_vtable_call() {
 **Solution**: Use the `longdouble` keyword in your signature. `infix`'s ABI logic contains the platform-specific rules to handle it correctly, whether it's passed on the x87 FPU stack (System V x64), in a 128-bit vector register (AArch64), or as a normal `double`.
 
 ```c
-#include <math.h>
+// long double native_sqrtl(long double x);
+const char* signature = "(longdouble) -> longdouble";
 
-// A simple function using long double.
-long double native_sqrtl(long double x) {
-    return sqrtl(x);
-}
+infix_forward_t* t = NULL;
+infix_forward_create(&t, signature, (void*)native_sqrtl, NULL);
 
-void recipe_long_double() {
-    // On platforms where long double is distinct (like Linux), this will
-    // trigger special ABI handling. On platforms where it's an alias for
-    // double (like Windows), infix will treat it as a double.
-    const char* signature = "(longdouble) -> longdouble";
+long double input = 144.0L;
+long double result = 0.0L;
+void* args[] = { &input };
 
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, signature, (void*)native_sqrtl, NULL);
-
-    long double input = 144.0L;
-    long double result = 0.0L;
-    void* args[] = { &input };
-
-    infix_forward_get_code(t)(&result, args);
-
-    printf("sqrtl(144.0L) = %Lf\n", result); // Expected: 12.0
-
-    infix_forward_destroy(t);
-}
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch04_Rec04_LongDouble.c`](/eg/cookbook/Ch04_Rec04_LongDouble.c).
 
 ### Recipe: Proving Reentrancy with Nested FFI Calls
 
@@ -1009,63 +707,29 @@ void recipe_long_double() {
 **Solution**: `infix` is designed to be fully reentrant. The library uses no global mutable state, and all error information is stored in thread-local storage. This recipe demonstrates a forward call that invokes a reverse callback, which in turn makes another forward call.
 
 ```c
-#include <string.h> // For memcpy
+// 1. Create the innermost forward trampoline (for `multiply`).
+infix_forward_t* fwd_multiply = NULL;
+infix_forward_create(&fwd_multiply, "(int, int)->int", (void*)multiply, NULL);
 
-// Innermost target function
-int multiply(int a, int b) { return a * b; }
+// 2. Create the reverse closure, passing the forward trampoline as user_data.
+//    The handler will use this trampoline to make the nested call.
+infix_reverse_t* rev_nested = NULL;
+infix_reverse_create_closure(&rev_nested, "(int)->int", nested_call_handler, fwd_multiply, NULL);
 
-// Because this handler needs state (the forward trampoline), we MUST use a closure.
-void nested_call_handler(infix_context_t* ctx, void* ret, void** args) {
-    // 1. Retrieve the forward trampoline from user_data.
-    infix_forward_t* fwd_trampoline = (infix_forward_t*)infix_reverse_get_user_data(ctx);
+// 3. Create the outermost forward trampoline (for `harness`).
+infix_forward_t* fwd_harness = NULL;
+const char* harness_sig = "(*((int)->int), int)->int";
+infix_forward_create(&fwd_harness, harness_sig, (void*)harness, NULL);
 
-    // 2. Unbox the argument.
-    int val = *(int*)args[0];
-    int multiplier = 5;
-    void* mult_args[] = { &val, &multiplier };
-
-    // 3. Make the nested forward call.
-    int result;
-    infix_forward_get_code(fwd_trampoline)(&result, mult_args);
-
-    // 4. Write the result to the return buffer.
-    memcpy(ret, &result, sizeof(int));
-}
-
-// The outer C function that takes our generated callback
-int harness(int (*func)(int), int input) {
-    return func(input);
-}
-
-void recipe_reentrancy() {
-    // 1. Create the innermost forward trampoline (for `multiply`)
-    infix_forward_t* fwd_multiply = NULL;
-    infix_forward_create(&fwd_multiply, "(int, int)->int", (void*)multiply, NULL);
-
-    // 2. Create the reverse closure, passing the forward trampoline as user_data
-    infix_reverse_t* rev_nested = NULL;
-    infix_reverse_create_closure(&rev_nested, "(int)->int", nested_call_handler, fwd_multiply, NULL);
-
-    // 3. Create the outermost forward trampoline (for `harness`)
-    infix_forward_t* fwd_harness = NULL;
-    const char* harness_sig = "(*((int)->int), int)->int";
-    infix_forward_create(&fwd_harness, harness_sig, (void*)harness, NULL);
-
-    // 4. Execute the call chain
-    void* callback_ptr = infix_reverse_get_code(rev_nested);
-    int base_val = 8;
-    void* harness_args[] = { &callback_ptr, &base_val };
-    int final_result;
-
-    infix_forward_get_code(fwd_harness)(&final_result, harness_args);
-    printf("Nested/reentrant call result: %d\n", final_result); // Expected: 8 * 5 = 40
-
-    // 5. Clean up all three trampolines
-    infix_forward_destroy(fwd_harness);
-    infix_reverse_destroy(rev_nested);
-    infix_forward_destroy(fwd_multiply);
-}
+// 4. Execute the call chain.
+void* callback_ptr = infix_reverse_get_code(rev_nested);
+int base_val = 8;
+void* harness_args[] = { &callback_ptr, &base_val };
+int final_result;
+infix_forward_get_code(fwd_harness)(&final_result, harness_args);
 ```
+
+> Full example available in [`Ch04_Rec05_Reentrancy.c`](/eg/cookbook/Ch04_Rec05_Reentrancy.c).
 
 ### Recipe: Proving Thread Safety
 
@@ -1074,72 +738,29 @@ void recipe_reentrancy() {
 **Solution**: `infix` trampoline handles (`infix_forward_t*` and `infix_reverse_t*`) are immutable after creation and are safe to share between threads. All error state is kept in thread-local storage, so calls from different threads will not interfere with each other.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#if defined(_WIN32)
-#include <windows.h>
-#else
-#include <pthread.h>
-#endif
+// Main thread: Create the trampoline.
+infix_forward_t* trampoline = NULL;
+infix_forward_create(&trampoline, "(int, int)->int", (void*)add, NULL);
 
-// A simple function to be the FFI target.
-int add(int a, int b) { return a + b; }
+// Main thread: Prepare data for the worker thread, including the callable pointer.
+thread_data_t data = { infix_forward_get_code(trampoline), 0 };
 
-// A struct to pass data to our worker thread.
-typedef struct {
-    infix_cif_func cif; // The callable trampoline function pointer.
-    int result;
-} thread_data_t;
+// Main thread: Spawn a worker thread.
+pthread_t thread_id;
+pthread_create(&thread_id, NULL, worker_thread_func, &data);
 
-// The function our worker thread will execute.
-#if defined(_WIN32)
-DWORD WINAPI worker_thread_func(LPVOID arg) {
-#else
-void* worker_thread_func(void* arg) {
-#endif
-    thread_data_t* data = (thread_data_t*)arg;
-    int a = 20, b = 22;
-    void* args[] = { &a, &b };
-    // Call the trampoline function pointer that was created on the main thread.
-    data->cif(&data->result, args);
-#if defined(_WIN32)
-    return 0;
-#else
-    return NULL;
-#endif
-}
-
-void recipe_thread_safety() {
-    // Main thread: Create the trampoline.
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create(&trampoline, "(int, int)->int", (void*)add, NULL);
-
-    thread_data_t data = { infix_forward_get_code(trampoline), 0 };
-
-    // Main thread: Spawn a worker thread, passing it the callable pointer.
-#if defined(_WIN32)
-    HANDLE thread_handle = CreateThread(NULL, 0, worker_thread_func, &data, 0, NULL);
-    WaitForSingleObject(thread_handle, INFINITE);
-    CloseHandle(thread_handle);
-#else
-    pthread_t thread_id;
-    pthread_create(&thread_id, NULL, worker_thread_func, &data);
-    pthread_join(thread_id, NULL);
-#endif
-
-    // Main thread: Check the result computed by the worker thread.
-    printf("Result from worker thread: %d\n", data.result); // Expected: 42
-
-    // Main thread: Clean up the trampoline.
-    infix_forward_destroy(trampoline);
-}
+// Worker thread (`worker_thread_func`):
+// ...
+//   data->cif(&data->result, args); // <-- FFI call happens here
+// ...
+pthread_join(thread_id, NULL);
 ```
+
+> Full example available in [`Ch04_Rec06_ThreadSafety.c`](/eg/cookbook/Ch04_Rec06_ThreadSafety.c).
 
 ---
 
 ## Chapter 5: Interoperability with Other Languages
-
-While `infix` can call any function with a C ABI, its true power shines when tackling complex interoperability challenges with more advanced languages like C++ and Rust. This chapter provides recipes for interfacing with other languages and with language features that don't have a direct C equivalent, such as virtual functions and stateful lambdas from C++.
 
 ### The Universal Principle: The C ABI
 
@@ -1151,78 +772,28 @@ While `infix` can call any function with a C ABI, its true power shines when tac
 
 **Solution**: Find the compiler-mangled names for the constructor, destructor, and methods. Use `infix` to call them directly, manually passing the `this` pointer as the first argument to methods.
 
-```cpp
-// File: MyClass.cpp (compile to libmyclass.so/.dll)
-#include <iostream>
-class MyClass {
-    int value;
-public:
-    MyClass(int val) : value(val) { std::cout << "C++ Constructor called.\n"; }
-    ~MyClass() { std::cout << "C++ Destructor called.\n"; }
-    int add(int x) { return this->value + x; }
-};
-extern "C" size_t get_myclass_size() { return sizeof(MyClass); }
-```
-
 ```c
-// File: main.c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <stdlib.h>
+// Mangled names depend on the compiler. This example gets them from a helper.
+const char* mangled_ctor = get_mangled_constructor();
+const char* mangled_getvalue = get_mangled_getvalue();
 
-// Mangled names depend on the compiler. Find them with `nm` or `dumpbin`.
-#if defined(__GNUC__) || defined(__clang__) // Itanium ABI
-const char* MANGLED_CONSTRUCTOR = "_ZN7MyClassC1Ei"; // MyClass::MyClass(int)
-const char* MANGLED_DESTRUCTOR = "_ZN7MyClassD1Ev";  // MyClass::~MyClass()
-const char* MANGLED_ADD = "_ZN7MyClass3addEi";      // MyClass::add(int)
-#elif defined(_MSC_VER) // MSVC ABI
-const char* MANGLED_CONSTRUCTOR = "??0MyClass@@QEAA@H@Z";
-const char* MANGLED_DESTRUCTOR = "??1MyClass@@QEAA@XZ";
-const char* MANGLED_ADD = "?add@MyClass@@QEAAHH@Z";
-#endif
+// Constructor is: void MyClass(MyClass* this, int val);
+infix_forward_create(&t_ctor, "(*void, int)->void", p_ctor, NULL);
 
-void recipe_cpp_mangled() {
-    infix_library_t* lib = infix_library_open("libmyclass.so"); // or .dll
-    if (!lib) return;
+// Method is: int getValue(const MyClass* this);
+infix_forward_create(&t_getval, "(*void)->int", p_getval, NULL);
 
-    void* p_ctor = infix_library_get_symbol(lib, MANGLED_CONSTRUCTOR);
-    void* p_dtor = infix_library_get_symbol(lib, MANGLED_DESTRUCTOR);
-    void* p_add = infix_library_get_symbol(lib, MANGLED_ADD);
-    size_t (*p_size)() = infix_library_get_symbol(lib, "get_myclass_size");
-    if (!p_ctor || !p_dtor || !p_add || !p_size) {
-        printf("Failed to find one or more symbols.\n");
-        infix_library_close(lib);
-        return;
-    }
+// --- Simulate `MyClass* obj = new MyClass(100);` ---
+void* obj = malloc(obj_size);
+int initial_val = 100;
+infix_forward_get_code(t_ctor)(NULL, (void*[]){ &obj, &initial_val });
 
-    infix_forward_t *t_ctor, *t_dtor, *t_add;
-    // Constructor is effectively: void __thiscall(void* this, int val)
-    infix_forward_create(&t_ctor, "(*void, int)->void", p_ctor, NULL);
-    // Destructor is: void __thiscall(void* this)
-    infix_forward_create(&t_dtor, "(*void)->void", p_dtor, NULL);
-    // Method is: int __thiscall(void* this, int x)
-    infix_forward_create(&t_add, "(*void, int)->int", p_add, NULL);
-
-    // --- Simulate `MyClass* obj = new MyClass(100);` ---
-    void* obj = malloc(p_size());
-    int initial_val = 100;
-    infix_forward_get_code(t_ctor)(NULL, (void*[]){ &obj, &initial_val });
-
-    // --- Simulate `int result = obj->add(23);` ---
-    int add_val = 23, result;
-    infix_forward_get_code(t_add)(&result, (void*[]){ &obj, &add_val });
-    printf("C++ mangled method returned: %d\n", result); // Should be 123
-
-    // --- Simulate `delete obj;` ---
-    infix_forward_get_code(t_dtor)(NULL, (void*[]){ &obj });
-    free(obj);
-
-    infix_library_close(lib);
-    infix_forward_destroy(t_ctor);
-    infix_forward_destroy(t_dtor);
-    infix_forward_destroy(t_add);
-}
+// --- Simulate `int result = obj->getValue();` ---
+int result;
+infix_forward_get_code(t_getval)(&result, (void*[]){ &obj });
 ```
+
+> Full example available in [`Ch05_Rec01_CppMangledNames.c`](/eg/cookbook/Ch05_Rec01_CppMangledNames.c) and library source in [`libs/MyClass.cpp`](/eg/cookbook/libs/MyClass.cpp).
 
 ### Recipe: Interfacing with C++ Templates
 
@@ -1230,63 +801,27 @@ void recipe_cpp_mangled() {
 
 **Solution**: You can't call the template itself, but you can call a *specific instantiation* of it. The compiler generates a normal function for each concrete type used with the template, and this function has a predictable mangled name that you can look up and call.
 
-```cpp
-// File: Box.cpp (compile to libbox.so/.dll)
-#include <iostream>
-template <typename T>
-class Box {
-    T value;
-public:
-    Box(T val) : value(val) {}
-    T get_value() { return this->value; }
-};
-
-// We need to explicitly instantiate the templates we want to use
-// so the compiler generates code for them.
-template class Box<int>;
-template class Box<double>;
-```
-
 ```c
-// File: main.c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <stdlib.h>
-
 // Mangled name for `Box<double>::get_value()` on GCC/Clang
 const char* MANGLED_GET_DBL = "_ZNK3BoxIdE9get_valueEv";
 
-void recipe_cpp_template() {
-    infix_library_t* lib = infix_library_open("libbox.so");
-    if (!lib) return;
+// In a real scenario, you would call the mangled constructor.
+// For simplicity here, we manually create the object layout.
+double val = 3.14;
+void* my_box = malloc(sizeof(double));
+memcpy(my_box, &val, sizeof(double));
 
-    // Manually create a Box<double> for this example.
-    double val = 3.14;
-    void* my_box = malloc(sizeof(double));
-    memcpy(my_box, &val, sizeof(double));
+void* p_get_value = infix_library_get_symbol(lib, MANGLED_GET_DBL);
 
-    void* p_get_value = infix_library_get_symbol(lib, MANGLED_GET_DBL);
-    if (!p_get_value) {
-        printf("Failed to find mangled template function.\n");
-        free(my_box);
-        infix_library_close(lib);
-        return;
-    }
+// Signature: double get_value(const Box<double>* this)
+infix_forward_t* t_get = NULL;
+infix_forward_create(&t_get, "(*void) -> double", p_get_value, NULL);
 
-    infix_forward_t* t_get = NULL;
-    // Signature: double get_value(Box<double>* this)
-    infix_forward_create(&t_get, "(*void) -> double", p_get_value, NULL);
-
-    double result;
-    infix_forward_get_code(t_get)(&result, (void*[]){ &my_box });
-
-    printf("Value from C++ template object: %f\n", result); // Should be 3.14
-
-    free(my_box);
-    infix_forward_destroy(t_get);
-    infix_library_close(lib);
-}
+double result;
+infix_forward_get_code(t_get)(&result, (void*[]){ &my_box });
 ```
+
+> Full example available in [`Ch05_Rec02_CppTemplates.c`](/eg/cookbook/Ch05_Rec02_CppTemplates.c) and library source in [`libs/Box.cpp`](/eg/cookbook/libs/Box.cpp).
 
 ### The Pattern for Other Compiled Languages
 
@@ -1402,37 +937,24 @@ Let's model the Windows `MessageBoxW` function, which takes two UTF-16 strings.
 
 #### Step 1: Define Semantic Aliases in a Registry
 
-Create a registry that defines aliases whose names convey meaning. These aliases still map to the correct underlying C types, but their names provide the context needed for introspection.
-
 ```c
-#include <infix/infix.h>
+infix_registry_t* registry = infix_registry_create();
 
-void recipe_semantic_string_types() {
-    infix_registry_t* registry = infix_registry_create();
+const char* string_types =
+    // Structural aliases for Windows types
+    "@HWND = *void;"
+    "@UINT = uint32;"
 
-    const char* string_types =
-        // Structural aliases for Windows types
-        "@HWND = *void;"
-        "@UINT = uint32;"
-
-        // Semantic aliases that describe intent, not just structure.
-        // We define them as structs so their names are preserved after resolution.
-        "@UTF16String = { data: *uint16 };" // Represents wchar_t* on Windows
-        "@UTF8String = { data: *char };"    // Represents const char*
-    ;
-    infix_register_types(registry, string_types);
-
-    // ... use the registry ...
-
-    infix_registry_destroy(registry);
-}
+    // Semantic aliases that describe intent, not just structure.
+    "@UTF16String = { data: *uint16 };" // Represents wchar_t*
+    "@UTF8String = { data: *char };"    // Represents const char*
+;
+infix_register_types(registry, string_types);
 ```
 
-> **Note:** We define `UTF16String` as `{*uint16}` instead of a direct alias `*uint16`. This is a crucial technique. By wrapping the pointer in a struct, the name `@UTF16String` refers to the struct itself. After resolution, the `.name` field is preserved on the struct type, making introspection possible.
+> **Note:** We define `UTF16String` as `{*uint16}` instead of a direct alias `*uint16`. This is a crucial technique. By wrapping the pointer in a struct, the name `@UTF16String` refers to the struct itself, making it inspectable.
 
 #### Step 2: Use the Aliases in Your Signature
-
-The signature for `MessageBoxW` now becomes self-documenting and machine-readable.
 
 ```c
 // Signature for: int MessageBoxW(HWND hwnd, LPCWSTR lpText, LPCWSTR lpCaption, UINT uType);
@@ -1441,186 +963,51 @@ const char* signature = "(@HWND, @UTF16String, @UTF16String, @UINT) -> int";
 
 #### Step 3: Introspect with Semantic Awareness
 
-Your language binding can now parse this signature and make intelligent decisions. The key is to check the **name of the resolved aggregate type**.
-
-**Conceptual Wrapper Introspection Logic:**
-
 ```c
-// 1. Parse the function signature with the registry.
+// 1. Parse the function signature to get its components.
 infix_signature_parse(signature, &arena, &ret, &args, &num_args, &num_fixed, registry);
 
-// 2. Introspect the type of the second argument (index 1).
-const infix_type* arg_type = args[1].type;
+// 2. Introspect the type of an argument.
+const infix_type* arg_type = args[1].type; // Second argument
 
 // 3. After resolution, `@UTF16String` is a STRUCT. Check its preserved name.
-if (arg_type->category == INFIX_TYPE_STRUCT && arg_type->meta.aggregate_info.name != NULL) {
-    const char* type_name = arg_type->meta.aggregate_info.name;
-
-    // 4. Check the semantic name.
-    if (strcmp(type_name, "UTF16String") == 0) {
+if (arg_type->category == INFIX_TYPE_STRUCT && arg_type->meta.aggregate_info.name) {
+    if (strcmp(arg_type->meta.aggregate_info.name, "UTF16String") == 0) {
         // This is our cue! Marshal the user's string as UTF-16.
-
-        // We can further introspect the struct's members to confirm the underlying type.
-        const infix_struct_member* member = infix_type_get_member(arg_type, 0);
-        const infix_type* pointer_type = member->type;
-        const infix_type* pointee_type = pointer_type->meta.pointer_info.pointee_type;
-
-        // assert(pointee_type->size == 2); // It's a 16-bit character.
-    }
-    else if (strcmp(type_name, "UTF8String") == 0) {
-        // Marshal as UTF-8.
     }
 }
 ```
 
-This pattern is the recommended approach. It keeps the core `infix` signature language focused on describing the C ABI accurately, while leveraging the type registry to provide the rich semantic information that high-level language bindings need.
+> Full example available in [`Ch05_Rec03_SemanticStrings.c`](/eg/cookbook/Ch05_Rec03_SemanticStrings.c).
 
 ### Recipe: Calling C++ Virtual Functions (V-Table Emulation)
 
 **Problem**: You have a pointer to a C++ polymorphic base class object (e.g., `Shape*`) and you need to call a `virtual` function on it from C, achieving true dynamic dispatch.
 
-**Solution**: Emulate what the C++ compiler does: manually read the object's v-table pointer (`vptr`), find the function pointer at the correct index within the v-table, and use `infix` to call it. Seriously, we're just swapping one problem for a new set of problems but we'll explain those later.
-
-First, the C++ library (`shapes.cpp`):
-
-```cpp
-#include <cmath>
-
-// On Windows, M_PI is not always defined in <cmath>
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-class Shape {
-public:
-    virtual double area() const = 0;        // 1st virtual function (index 0)
-    virtual const char * name() const = 0;  // 2nd virtual function (index 1)
-    virtual ~Shape() = default;             // 3rd virtual function (index 2)
-};
-
-class Rectangle : public Shape {
-    double w, h;
-
-public:
-    Rectangle(double width, double height) : w(width), h(height) {}
-    double area() const override { return w * h; }
-    const char * name() const override { return "Rectangle"; }
-};
-
-class Circle : public Shape {
-    double r;
-
-public:
-    Circle(double radius) : r(radius) {}
-    double area() const override { return M_PI * r * r; }
-    const char * name() const override { return "Circle"; }
-};
-
-// extern "C" factory functions to create C++ objects from C.
-extern "C" {
-    //  Keep the factory function as it's the only robust way to construct.
-    Shape * create_rectangle(double w, double h) { return new Rectangle(w, h); }
-    Shape * create_circle(double r) { return new Circle(r); }
-    // We can now REMOVE the destroy_shape wrapper *if* we call the destructor directly.
-    // void destroy_shape(Shape * s) { delete s; }
-}
-```
-
-Now, the C code using `infix` to call the `virtual` methods:
+**Solution**: Emulate what the C++ compiler does: manually read the object's v-table pointer (`vptr`), find the function pointer at the correct index within the v-table, and use `infix` to call it.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <stdlib.h>
+// 1. Create a C++ object via a factory function.
+void* rect_obj = create_rectangle(10.0, 5.0);
 
-#if defined(_WIN32)
-const char * LIB_NAME = "libshapes.dll";
-#else
-const char * LIB_NAME = "./libshapes.so";
-#endif
+// 2. Manually read the v-table pointer from the object's memory.
+void** vptr = (void**)rect_obj;
+void** vtable = *vptr;
 
-int main() {
-    printf("--- Cookbook Chapter 5, Recipe 4: Calling C++ Virtual Functions ---\n");
+// 3. Read function pointers from their known indices in the v-table.
+void* area_fn_ptr = vtable[0]; // double area() const -> index 0
+void* name_fn_ptr = vtable[1]; // const char* name() const -> index 1
 
-    infix_library_t * lib = infix_library_open(LIB_NAME);
-    if (!lib) {
-        fprintf(stderr, "Failed to open library '%s'.\n", LIB_NAME);
-        return 1;
-    }
+// 4. Create trampolines for the discovered function pointers.
+infix_forward_create(&t_area, "(*void)->double", area_fn_ptr, NULL);
+infix_forward_create(&t_name, "(*void)->*char", name_fn_ptr, NULL);
 
-    // 1. Get the extern "C" factory function (the correct way to construct).
-    void * (*create_rectangle)(double, double) = infix_library_get_symbol(lib, "create_rectangle");
-
-    // 2. Create a C++ object via the factory.
-    void * rect_obj = create_rectangle(10.0, 5.0);
-    printf("Created C++ Rectangle object at address %p.\n", rect_obj);
-
-    // 3. Manually read the v-table pointer from the object.
-    void ** vptr = (void **)rect_obj;
-    void ** vtable = *vptr;
-    printf("Read v-table pointer: %p\n", (void *)vtable);
-
-    // 4. Read function pointers from their known indices in the v-table.
-    //    This is ABI-dependent and can be fragile.
-    void * area_fn_ptr = vtable[0];      // double area() const
-    void * name_fn_ptr = vtable[1];      // const char* name() const
-    void * dtor_fn_ptr = vtable[2];      // virtual ~Shape()
-    printf("Found `area()` function pointer at vtable[0]: %p\n", area_fn_ptr);
-    printf("Found `name()` function pointer at vtable[1]: %p\n", name_fn_ptr);
-    printf("Found `~Shape()` function pointer at vtable[2]: %p\n", dtor_fn_ptr);
-
-    // 5. Create trampolines for the discovered function pointers.
-    infix_forward_t *t_area, *t_name, *t_dtor;
-    infix_forward_create(&t_area, "(*void)->double", area_fn_ptr, NULL);
-    infix_forward_create(&t_name, "(*void)->*char", name_fn_ptr, NULL);
-    infix_forward_create(&t_dtor, "(*void)->void", dtor_fn_ptr, NULL);
-
-    // 6. Prepare the arguments array for the member function calls.
-    //    The only argument is the `this` pointer.
-    void* args[] = { &rect_obj };
-
-    // 7. Call the virtual functions.
-    double rect_area;
-    const char * rect_name;
-    infix_forward_get_code(t_area)(&rect_area, args);
-    infix_forward_get_code(t_name)((void*)&rect_name, args);
-
-    printf("\nResults:\n");
-    printf("  Object's virtual name() returned: '%s'\n", rect_name);
-    printf("  Object's virtual area() returned: %f\n", rect_area);
-
-    // 8. Call the virtual destructor directly instead of an extern "C" wrapper.
-    printf("\nCalling virtual destructor at %p...\n", dtor_fn_ptr);
-    infix_forward_get_code(t_dtor)(NULL, args);
-    printf("Object destroyed.\n");
-
-    // 9. Clean up.
-    infix_forward_destroy(t_area);
-    infix_forward_destroy(t_name);
-    infix_forward_destroy(t_dtor);
-    infix_library_close(lib);
-
-    return 0;
-}
+// 5. Call the virtual functions, passing the object as the `this` pointer.
+double rect_area;
+infix_forward_get_code(t_area)(&rect_area, (void*[]){ &rect_obj });
 ```
 
-And now you have a new problem.
-
-**Problem with this Solution**: The `Shape` class correctly declares a `virtual` destructor. This is key because when a class has at least one virtual function, the compiler adds its virtual destructor to the v-table to ensure that the correct derived-class destructor is called durring polymorphic deletion (`Shape * s = new Rectangle(); delete s;`).
-
-This means we can find the destructor's address in the v-table, create a trampoline for it, and call it. This is fragile because the layout of the v-table is not ABI agnostic; each platform and compiler will have their own minor differences with how it's layed out. However, for simple, single-inheritance hierachies, the order of virtual functions in the v-table typically mirrors their declaration order in the base class.
-
-Unfortunatly, you cannot expect to find and call the correct constructor this way for several reasons:
-
-1.  **Constructors Aren't "Normal" Functions:** A constructor's job is not just to execute code but to **initialize a raw block of memory**. The C++ `new` operator is a two-step process:
-    *   **Allocation:** It first calls `operator new` (a global function, often wrapping `malloc`) to allocate enough memory for the object.
-    *   **Initialization:** It then calls the constructor, passing the address of this new memory block as the hidden `this` pointer. The constructor runs, initializes member variables, and crucially, **sets the v-table pointer (`vptr`)** at the beginning of the memory block.
-
-2.  **No Single Callable Symbol:** The expression `new Rectangle(10.0, 5.0)` is a high-level language feature. The compiler doesn't generate a single, standalone function named `Rectangle` that you can look up. Instead, it generates a block of code at the call site to handle the allocation-then-initialization sequence.
-
-3.  **Name Mangling and Calling Conventions:** Even if you could find the constructor's code, it would have a "mangled" name (e.g., `_ZN9RectangleC1Edd` on Linux) that is complex and compiler-specific. Furthermore, its calling convention is different from a normal function and is not something a general-purpose FFI library is designed to handle.
-
-This is why `extern "C"` factory functions like our `create_rectangle` are needed. Honestly, you should always use exported "C" wrapers for creating and destroying C++ objects from `infix`.
+> Full example available in [`Ch05_Rec04_CppVirtualFunctions.c`](/eg/cookbook/Ch05_Rec04_CppVirtualFunctions.c) and library source in [`libs/shapes.cpp`](/eg/cookbook/libs/shapes.cpp).
 
 ### Recipe: Bridging C++ Callbacks (`std::function`) and Lambdas
 
@@ -1628,116 +1015,31 @@ This is why `extern "C"` factory functions like our `create_rectangle` are neede
 
 **Solution**: This is a powerful, two-way FFI interaction. You will create an `infix` closure to represent your C-side state, and then call a mangled C++ method to register that closure's components (its C function pointer and its state pointer) with the C++ object.
 
-First, the C++ library that takes a callback:
-
-```cpp
-// File: EventManager.cpp (compile to libeventmanager.so/.dll)
-#include <functional>
-#include <iostream>
-
-class EventManager {
-    // We store the C-style callback parts.
-    void (*handler_ptr)(int, void*);
-    void* user_data;
-public:
-    EventManager() : handler_ptr(nullptr), user_data(nullptr) {
-        std::cout << "C++ EventManager constructed.\n";
-    }
-    // A method to register a C-style callback.
-    void set_handler(void (*h)(int, void*), void* data) {
-        this->handler_ptr = h;
-        this->user_data = data;
-    }
-    // A method to trigger the stored callback.
-    void trigger(int value) {
-        if (handler_ptr) {
-            std::cout << "C++ is triggering the callback with value " << value << "...\n";
-            handler_ptr(value, user_data);
-        }
-    }
-};
-```
-
-Now, the C application that provides a stateful callback to the `EventManager` object:
-
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <stdlib.h>
+// 1. Create the C-side state and the infix closure.
+C_AppState app_state = {0};
+infix_reverse_t* closure = NULL;
+infix_reverse_create_closure(&closure, "(int, *void)->void", my_closure_handler, &app_state, NULL);
 
-// On GCC/Clang, find these with: nm -C libeventmanager.so | grep EventManager
-const char* MANGLED_CTOR = "_ZN12EventManagerC1Ev";
-const char* MANGLED_SET_HANDLER = "_ZN12EventManager10set_handlerEPFviPvES_";
-const char* MANGLED_TRIGGER = "_ZN12EventManager7triggerEi";
+// 2. Create an instance of the C++ EventManager object.
+void* manager_obj = malloc(get_size());
+infix_forward_create(&t_ctor, "(*void)->void", p_ctor, NULL);
+infix_forward_get_code(t_ctor)(NULL, &manager_obj);
 
-// Our C application's state and the generic handler for our infix closure.
-typedef struct { int call_count; } C_AppState;
+// 3. Call the C++ `set_handler` method to register our closure's components.
+const char* sig = "(*void, *((int, *void)->void), *void)->void";
+infix_forward_create(&t_set_handler, sig, p_set_handler, NULL);
+void* closure_c_func = infix_reverse_get_code(closure);
+void* closure_user_data = infix_reverse_get_user_data(closure);
+void* set_handler_args[] = { &manager_obj, &closure_c_func, &closure_user_data };
+infix_forward_get_code(t_set_handler)(NULL, set_handler_args);
 
-void my_closure_handler(infix_context_t* context, void* ret, void** args) {
-    (void)ret;
-    C_AppState* state = (C_AppState*)infix_reverse_get_user_data(context);
-    state->call_count++;
-
-    int value_from_cpp = *(int*)args[0];
-    printf("C handler called (invocation #%d)! Received value: %d\n", state->call_count, value_from_cpp);
-}
-
-void recipe_cpp_callback() {
-    infix_library_t* lib = infix_library_get_symbol(lib, "libeventmanager.so");
-    if(!lib) return;
-
-    // 1. Get pointers to the mangled C++ methods.
-    void* p_ctor = infix_library_get_symbol(lib, MANGLED_CTOR);
-    void* p_set_handler = infix_library_get_symbol(lib, MANGLED_SET_HANDLER);
-    void* p_trigger = infix_library_get_symbol(lib, MANGLED_TRIGGER);
-
-    // 2. Create the C-side state and the infix closure.
-    C_AppState app_state = {0};
-    infix_reverse_t* closure = NULL;
-    infix_reverse_create_closure(&closure, "(int, *void)->void", my_closure_handler, &app_state, NULL);
-
-    // 3. Create an instance of the C++ EventManager object.
-    // Constructor signature: void EventManager(EventManager* this);
-    void* manager_obj = malloc(sizeof(void*)*2); // Allocate space for the object.
-    infix_forward_t* t_ctor;
-    infix_forward_create(&t_ctor, "(*void)->void", p_ctor, NULL);
-    infix_forward_get_code(t_ctor)(NULL, &manager_obj);
-
-    // 4. Call the set_handler method to register our closure.
-    // Signature: void set_handler(EventManager* this, void (*h)(int, void*), void* data);
-    // Becomes: "(*void, *(*(...)), *void) -> void"
-    infix_forward_t* t_set_handler;
-    infix_forward_create(&t_set_handler, "(*void, *((*void)->void), *void)->void", p_set_handler, NULL);
-
-    void* closure_c_func = infix_reverse_get_code(closure);
-    void* closure_user_data = infix_reverse_get_user_data(closure);
-    void* set_handler_args[] = { &manager_obj, &closure_c_func, &closure_user_data };
-    infix_forward_get_code(t_set_handler)(NULL, set_handler_args);
-
-    // 5. Call the trigger method to make the C++ object invoke our callback.
-    // Signature: void trigger(EventManager* this, int value);
-    infix_forward_t* t_trigger;
-    infix_forward_create(&t_trigger, "(*void, int)->void", p_trigger, NULL);
-
-    int value_to_send = 42;
-    void* trigger_args[] = { &manager_obj, &value_to_send };
-    infix_forward_get_code(t_trigger)(NULL, trigger_args); // First call
-
-    value_to_send = 99;
-    infix_forward_get_code(t_trigger)(NULL, trigger_args); // Second call
-
-    printf("Final C-side call count: %d\n", app_state.call_count); // Expected: 2
-
-    // 6. Clean up.
-    // Note: The destructor would need to be called here in a real application.
-    free(manager_obj);
-    infix_forward_destroy(t_ctor);
-    infix_forward_destroy(t_set_handler);
-    infix_forward_destroy(t_trigger);
-    infix_reverse_destroy(closure);
-    infix_library_close(lib);
-}
+// 4. Call the C++ `trigger` method to make it invoke our C callback.
+infix_forward_create(&t_trigger, "(*void, int)->void", p_trigger, NULL);
+// ...
 ```
+
+> Full example available in [`Ch05_Rec05_CppCallbacks.cpp`](/eg/cookbook/Ch05_Rec05_CppCallbacks.cpp) and library source in [`libs/EventManager.cpp`](/eg/cookbook/libs/EventManager.cpp).
 
 ## Chapter 6: Dynamic Libraries & System Calls
 
@@ -1747,56 +1049,28 @@ void recipe_cpp_callback() {
 
 **Solution**: Use `infix`'s cross-platform library loading API to get a handle to the library and the function pointer, then create a trampoline.
 
-> **Finding Mangled Names**
-> This recipe relies on finding the "mangled" or "decorated" names that the C++ compiler generates for functions. You can find these names using your platform's tools:
-> - Linux/macOS: `nm -C mylibrary.so` or `readelf -sW mylibrary.so`
-> - Windows: `dumpbin /SYMBOLS mylibrary.dll` or `nm -C mylibrary.dll`
-
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
+// 1. Open the system library by name.
+infix_library_t* user32 = infix_library_open("user32.dll");
 
-#if defined(_WIN32)
-#include <windows.h> // For UINT
-void recipe_system_call() {
-    infix_library_t* user32 = infix_library_open("user32.dll");
-    if (!user32) {
-        printf("Failed to open user32.dll\n");
-        return;
-    }
+// 2. Look up the address of the `MessageBoxA` function.
+void* pMessageBoxA = infix_library_get_symbol(user32, "MessageBoxA");
 
-    void* pMessageBoxA = infix_library_get_symbol(user32, "MessageBoxA");
-    if (!pMessageBoxA) {
-        printf("Failed to find MessageBoxA\n");
-        infix_library_close(user32);
-        return;
-    }
+// 3. Define the signature and create the trampoline.
+//    int MessageBoxA(HWND hWnd, LPCSTR lpText, LPCSTR lpCaption, UINT uType);
+const char* sig = "(*void, *char, *char, uint32) -> int";
+infix_forward_t* t = NULL;
+infix_forward_create(&t, sig, pMessageBoxA, NULL);
 
-    // int MessageBoxA(HWND hWnd, LPCSTR lpText, LPCSTR lpCaption, UINT uType);
-    // Note: HWND is a pointer, LPCSTR is *char, UINT is uint32.
-    const char* sig = "(*void, *char, *char, uint32) -> int";
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, sig, pMessageBoxA, NULL);
-
-    void* hwnd = NULL;
-    const char* text = "Hello from a dynamically loaded function!";
-    const char* caption = "infix FFI";
-    uint32_t type = 0; // MB_OK
-    void* args[] = { &hwnd, &text, &caption, &type };
-    int result;
-
-    infix_forward_get_code(t)(&result, args);
-
-    infix_forward_destroy(t);
-    infix_library_close(user32);
-}
-#else
-// Dummy implementation for non-Windows platforms to allow compilation.
-void recipe_system_call() {
-    printf("This recipe is for Windows only.\n");
-}
-#endif
+// 4. Prepare arguments and call the function.
+void* hwnd = NULL;
+const char* text = "Hello from a dynamically loaded function!";
+// ...
+int result;
+infix_forward_get_code(t)(&result, args);
 ```
+
+> Full example available in [`Ch06_Rec01_SystemLibraries.c`](/eg/cookbook/Ch06_Rec01_SystemLibraries.c).
 
 ### Recipe: Reading and Writing Global Variables
 
@@ -1806,98 +1080,37 @@ void recipe_system_call() {
 
 #### Example 1: Simple Integer Variable
 
-First, create a simple shared library (`libglobals.c`) that exports a counter:
-
 ```c
-// libglobals.c - Compile to a shared library
-#if defined(_WIN32)
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+infix_library_t* lib = infix_library_open("./libglobals.so");
 
-EXPORT int global_counter = 42;
-```
+int counter_val = 0;
+// 1. Read the initial value. The signature is simply the type of the variable.
+infix_read_global(lib, "global_counter", "int", &counter_val, NULL);
 
-Now, the C code to interact with it:
+// 2. Write a new value to the global variable.
+int new_val = 100;
+infix_write_global(lib, "global_counter", "int", &new_val, NULL);
 
-```c
-#include <infix/infix.h>
-#include <stdio.h>
-
-void recipe_global_int() {
-    infix_library_t* lib = infix_library_open("./libglobals.so"); // or "libglobals.dll"
-    if (!lib) return;
-
-    int counter_val = 0;
-
-    // 1. Read the initial value. The signature is simply the type of the variable.
-    infix_read_global(lib, "global_counter", "int", &counter_val);
-    printf("Initial value of global_counter: %d\n", counter_val); // Expected: 42
-
-    // 2. Write a new value to the global variable.
-    int new_val = 100;
-    infix_write_global(lib, "global_counter", "int", &new_val);
-
-    // 3. Read the value again to confirm it was changed.
-    counter_val = 0; // Reset our local variable
-    infix_read_global(lib, "global_counter", "int", &counter_val);
-    printf("New value of global_counter: %d\n", counter_val); // Expected: 100
-
-    infix_library_close(lib);
-}
+// 3. Read it back to confirm.
+infix_read_global(lib, "global_counter", "int", &counter_val, NULL);
 ```
 
 #### Example 2: Aggregate (Struct) Variable
 
-Let's expand `libglobals.c` to export a configuration struct:
-
 ```c
-// Add to libglobals.c
-typedef struct {
-    const char* name;
-    int version;
-} Config;
+infix_registry_t* reg = infix_registry_create();
+infix_register_types(reg, "@Config = {*char, int};");
 
-EXPORT Config g_config = { "default", 1 };
+Config local_config;
+// 1. Read the global struct into our local variable.
+infix_read_global(lib, "g_config", "@Config", &local_config, reg);
+
+// 2. Modify and write the struct back to the library.
+Config new_config = { "updated", 2 };
+infix_write_global(lib, "g_config", "@Config", &new_config, reg);
 ```
 
-Now, the C code to read and write this struct:
-
-```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <string.h>
-
-typedef struct { const char* name; int version; } Config;
-
-void recipe_global_struct() {
-    infix_library_t* lib = infix_library_open("./libglobals.so");
-    if (!lib) return;
-
-    // It's good practice to use the registry for structs.
-    infix_registry_t* reg = infix_registry_create();
-    infix_register_types(reg, "@Config = {*char, int};");
-
-    Config local_config;
-
-    // 1. Read the global struct into our local variable.
-    infix_read_global(lib, "g_config", "@Config", &local_config);
-    printf("Initial config: name='%s', version=%d\n", local_config.name, local_config.version);
-
-    // 2. Modify and write the struct back to the library.
-    Config new_config = { "updated", 2 };
-    infix_write_global(lib, "g_config", "@Config", &new_config);
-
-    // 3. Read it back to verify the change.
-    memset(&local_config, 0, sizeof(Config));
-    infix_read_global(lib, "g_config", "@Config", &local_config);
-    printf("Updated config: name='%s', version=%d\n", local_config.name, local_config.version);
-
-    infix_registry_destroy(reg);
-    infix_library_close(lib);
-}
-```
+> Full example available in [`Ch06_Rec02_GlobalVariables.c`](/eg/cookbook/Ch06_Rec02_GlobalVariables.c) and library source in [`libs/libglobals.c`](/eg/cookbook/libs/libglobals.c).
 
 ### Recipe: Handling Library Dependencies
 
@@ -1906,35 +1119,18 @@ void recipe_global_struct() {
 **Solution:** You don't have to do anything special. On all modern operating systems, the dynamic linker will automatically find, load, and link `libB` when you load `libA`.
 
 ```c
-// libB.c -> provides a helper function
-int helper_from_lib_b() { return 100; }
+// We only need to open libA. The OS will handle loading libB.
+infix_library_t* lib = infix_library_open("./libA.so");
 
-// libA.c -> depends on libB
-int helper_from_lib_b();
-int entry_point_a() { return 200 + helper_from_lib_b(); }
+void* p_entry = infix_library_get_symbol(lib, "entry_point_a");
+infix_forward_t* t = NULL;
+infix_forward_create(&t, "()->int", p_entry, NULL);
 
-// How to compile:
-// gcc -shared -fPIC -o libB.so libB.c
-// gcc -shared -fPIC -o libA.so libA.c -L. -lB // Link libA against libB
-
-void recipe_library_dependencies() {
-    // We only need to open libA. The OS will handle loading libB.
-    infix_library_t* lib = infix_library_open("./libA.so");
-    if (!lib) return;
-
-    void* p_entry = infix_library_get_symbol(lib, "entry_point_a");
-    infix_forward_t* t = NULL;
-    infix_forward_create(&t, "()->int", p_entry, NULL);
-
-    int result;
-    infix_forward_get_code(t)(&result, NULL);
-
-    printf("Result from chained libraries: %d\n", result); // Should be 300
-
-    infix_forward_destroy(t);
-    infix_library_close(lib);
-}
+int result;
+infix_forward_get_code(t)(&result, NULL);
 ```
+
+> Full example available in [`Ch06_Rec03_LibraryDependencies.c`](/eg/cookbook/Ch06_Rec03_LibraryDependencies.c) and library sources in [`libs/libA.c`](/eg/cookbook/libs/libA.c) and [`libs/libB.c`](/eg/cookbook/libs/libB.c).
 
 ---
 
@@ -1947,39 +1143,23 @@ void recipe_library_dependencies() {
 **Solution**: Use `infix_type_from_signature` to parse a signature into a detailed `infix_type` graph. This graph contains all the `size`, `alignment`, and member `offset` information needed to correctly write data into a C-compatible memory buffer.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdint.h>
-
-typedef struct { int32_t user_id; double score; const char* name; } UserProfile;
-
 void marshal_ordered_data(void* dest, const char* sig, void** src) {
+    // 1. Parse the signature to get the struct's layout information.
     infix_type* type = NULL;
     infix_arena_t* arena = NULL;
-    if (infix_type_from_signature(&type, &arena, sig, NULL) != INFIX_SUCCESS) return;
+    infix_type_from_signature(&type, &arena, sig, NULL);
 
+    // 2. Iterate through the struct's members.
     for (size_t i = 0; i < infix_type_get_member_count(type); ++i) {
         const infix_struct_member* member = infix_type_get_member(type, i);
+        // 3. Use the offset and size to copy data into the correct location.
         memcpy((char*)dest + member->offset, src[i], infix_type_get_size(member->type));
     }
     infix_arena_destroy(arena);
 }
-
-void recipe_dynamic_packing() {
-    int32_t id = 123;
-    double score = 98.6;
-    const char* name = "Sanko";
-    void* my_data[] = { &id, &score, &name };
-
-    const char* profile_sig = "{id:int32, score:double, name:*char}";
-    UserProfile profile_buffer = {0};
-
-    marshal_ordered_data(&profile_buffer, profile_sig, my_data);
-    printf("Resulting C struct: id=%d, score=%.1f, name=%s\n",
-           profile_buffer.user_id, profile_buffer.score, profile_buffer.name);
-}
 ```
+
+> Full example available in [`Ch07_Rec01_DynamicMarshalling.c`](/eg/cookbook/Ch07_Rec01_DynamicMarshalling.c).
 
 ### Recipe: Building a Signature String at Runtime
 
@@ -1992,37 +1172,22 @@ void recipe_dynamic_packing() {
 const char* user_defined_fields[] = { "int", "int", "double" };
 int num_fields = 3;
 
-void recipe_dynamic_signature() {
-    char signature_buffer = "{";
-    char* current = signature_buffer + 1;
-    size_t remaining = sizeof(signature_buffer) - 1;
-
-    // 1. Build the signature string dynamically.
-    for (int i = 0; i < num_fields; ++i) {
-        int written = snprintf(current, remaining, "%s%s", user_defined_fields[i], (i == num_fields - 1) ? "" : ",");
-        if (written < 0 || (size_t)written >= remaining) {
-            printf("Error: Signature buffer too small.\n");
-            return;
-        }
-        current += written;
-        remaining -= written;
-    }
-    strcat(signature_buffer, "}"); // Final string is "{int,int,double}"
-
-    printf("Dynamically generated signature: %s\n", signature_buffer);
-
-    // 2. Use the dynamic signature to get layout information.
-    infix_type* dynamic_type = NULL;
-    infix_arena_t* arena = NULL;
-    infix_type_from_signature(&dynamic_type, &arena, signature_buffer, NULL);
-
-    if (dynamic_type) {
-        printf("Dynamic struct size: %zu bytes\n", infix_type_get_size(dynamic_type));
-    }
-
-    infix_arena_destroy(arena);
+char signature_buffer[256] = "{";
+// 1. Build the signature string dynamically.
+for (int i = 0; i < num_fields; ++i) {
+    strcat(signature_buffer, user_defined_fields[i]);
+    if (i < num_fields - 1) strcat(signature_buffer, ",");
 }
+strcat(signature_buffer, "}"); // Final string is "{int,int,double}"
+
+// 2. Use the dynamic signature to get layout information.
+infix_type* dynamic_type = NULL;
+infix_arena_t* arena = NULL;
+infix_type_from_signature(&dynamic_type, &arena, signature_buffer, NULL);
+// ...
 ```
+
+> Full example available in [`Ch07_Rec02_DynamicSignatures.c`](/eg/cookbook/Ch07_Rec02_DynamicSignatures.c).
 
 ### Recipe: Introspecting a Trampoline for a Wrapper
 
@@ -2032,15 +1197,22 @@ void recipe_dynamic_signature() {
 
 ```c
 void dynamic_wrapper(infix_forward_t* trampoline, void* target_func, void** args, size_t num_provided_args) {
-    if (num_provided_args != infix_forward_get_num_args(trampoline)) {
-        fprintf(stderr, "Error: Incorrect number of arguments. Expected %zu, got %zu.\n",
-                infix_forward_get_num_args(trampoline), num_provided_args);
+    // 1. Introspect the trampoline to get expected argument count.
+    size_t num_expected_args = infix_forward_get_num_args(trampoline);
+
+    if (num_provided_args != num_expected_args) {
+        fprintf(stderr, "Error: Incorrect number of arguments...\n");
         return;
     }
     // A real binding would also check the types using infix_forward_get_arg_type().
-    ((infix_unbound_cif_func)infix_forward_get_unbound_code(trampoline))(target_func, NULL, args);
+
+    // 2. Make the call.
+    infix_unbound_cif_func cif = infix_forward_get_unbound_code(trampoline);
+    cif(target_func, NULL, args);
 }
 ```
+
+> Full example available in [`Ch07_Rec03_IntrospectWrapper.c`](/eg/cookbook/Ch07_Rec03_IntrospectWrapper.c).
 
 ---
 
@@ -2089,50 +1261,26 @@ void recipe_custom_arena() {
 **Solution**: Use an arena to build your `infix_type` objects and then pass them directly to the `_manual` variant of the creation functions.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <stddef.h> // For offsetof
+// 1. Create an arena to hold all our type definitions.
+infix_arena_t* arena = infix_arena_create(4096);
 
-// The C types and function we want to call
-typedef struct { double x, y; } Point;
-Point move_point(Point p, double dx) { p.x += dx; return p; }
+// 2. Manually define the 'Point' struct type.
+infix_struct_member point_members[] = {
+    infix_type_create_member("x", infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE), offsetof(Point, x)),
+    infix_type_create_member("y", infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE), offsetof(Point, y))
+};
+infix_type* point_type = NULL;
+infix_type_create_struct(arena, &point_type, point_members, 2);
 
-void recipe_full_manual_api() {
-    // 1. Create an arena to hold all our type definitions.
-    infix_arena_t* arena = infix_arena_create(4096);
+// 3. Define the argument types for the function.
+infix_type* arg_types[] = { point_type, infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE) };
 
-    // 2. Manually define the 'Point' struct type.
-    infix_struct_member point_members[] = {
-        infix_type_create_member("x", infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE), offsetof(Point, x)),
-        infix_type_create_member("y", infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE), offsetof(Point, y))
-    };
-    infix_type* point_type = NULL;
-    infix_type_create_struct(arena, &point_type, point_members, 2);
-
-    // 3. Define the argument types for the function `Point move_point(Point, double)`.
-    infix_type* arg_types[] = {
-        point_type,
-        infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE)
-    };
-
-    // 4. Create the trampoline using the manually created types.
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create_manual(&trampoline, point_type, arg_types, 2, 2, (void*)move_point);
-
-    // 5. Call the function.
-    Point start = { 10.0, 20.0 };
-    double delta_x = 5.5;
-    void* args[] = { &start, &delta_x };
-    Point end;
-
-    infix_forward_get_code(trampoline)(&end, args);
-    printf("Manual API result: Moved point has x = %f\n", end.x); // Should be 15.5
-
-    // 6. Clean up.
-    infix_forward_destroy(trampoline);
-    infix_arena_destroy(arena); // Frees the 'point_type' as well.
-}
+// 4. Create the trampoline using the manually created types.
+infix_forward_t* trampoline = NULL;
+infix_forward_create_manual(&trampoline, point_type, arg_types, 2, 2, (void*)move_point);
 ```
+
+> Full example available in [`Ch08_Rec02_ManualAPI.c`](/eg/cookbook/Ch08_Rec02_ManualAPI.c).
 
 ### Recipe: Using Custom Memory Allocators
 
@@ -2141,41 +1289,21 @@ void recipe_full_manual_api() {
 **Solution**: `infix` provides override macros (`infix_malloc`, `infix_free`, etc.). Define these macros *before* you include `infix.h` to redirect all of its internal memory operations.
 
 ```c
-#include <stdio.h>
-#include <stdlib.h>
-
 // 1. Define your custom memory management functions.
-static size_t g_total_allocated = 0;
-void* tracking_malloc(size_t size) {
-    g_total_allocated += size;
-    printf(">> Custom Malloc: Allocating %zu bytes (Total: %zu)\n", size, g_total_allocated);
-    return malloc(size);
-}
-
-void tracking_free(void* ptr) {
-    printf(">> Custom Free\n");
-    free(ptr);
-}
+static void* tracking_malloc(size_t size) { /* ... */ }
+static void tracking_free(void* ptr) { /* ... */ }
 
 // 2. Define the infix override macros BEFORE including infix.h
 #define infix_malloc(size) tracking_malloc(size)
 #define infix_free(ptr)    tracking_free(ptr)
-// You can also override infix_calloc and infix_realloc if needed.
 
 #include <infix/infix.h>
 
-void recipe_custom_allocators() {
-    printf("Creating trampoline with custom allocators\n");
-    infix_forward_t* trampoline = NULL;
-    // All internal allocations for the trampoline will now use tracking_malloc.
-    infix_forward_create(&trampoline, "()->void", (void*)recipe_custom_allocators, NULL);
-
-    printf("Destroying trampoline\n");
-    // The free operations will now use tracking_free.
-    infix_forward_destroy(trampoline);
-    printf("Done\n");
-}
+// Now, all calls like infix_forward_create will use your allocators.
+infix_forward_create(&trampoline, "()->void", (void*)dummy_func, NULL);
 ```
+
+> Full example available in [`Ch08_Rec01_CustomAllocators.c`](/eg/cookbook/Ch08_Rec01_CustomAllocators.c).
 
 ### Recipe: Building a Dynamic Call Frame with an Arena
 
@@ -2184,76 +1312,29 @@ void recipe_custom_allocators() {
 **Solution**: Use an `infix` arena to allocate memory for both the unboxed C values *and* the `void**` array that points to them. This makes the entire call frame a single, contiguous block of memory that can be allocated and freed with extreme efficiency.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-#include <stdarg.h> // For va_list
-#include <string.h> // For memcpy
-
-// A sample C function we want to call dynamically.
-void process_user_data(int id, double score, const char* name) {
-    printf("C Function Received: ID=%d, Score=%.2f, Name='%s'\n", id, score, name);
-}
-
-// This function simulates the core logic of a language binding's generic "call" function.
-// It takes a va_list to represent dynamic arguments coming from a script.
-void dynamic_ffi_call(infix_forward_t* trampoline, void* target_func, int arg_count, ...) {
+void dynamic_ffi_call(infix_forward_t* trampoline, ...) {
     // 1. Create a temporary arena for this call's entire data frame.
     infix_arena_t* call_arena = infix_arena_create(4096);
-    if (!call_arena) {
-        fprintf(stderr, "Error: Could not create call arena.\n");
-        return;
-    }
 
     // 2. Allocate the void** array itself from the arena.
     void** args = infix_arena_alloc(call_arena, sizeof(void*) * arg_count, _Alignof(void*));
 
-    va_list va;
-    va_start(va, arg_count);
-
-    // 3. For each argument, allocate space for its C value in the arena,
-    //    copy the value, and store the pointer in the `args` array.
+    // 3. For each argument, allocate space for its C value in the arena and set the pointer.
     for (int i = 0; i < arg_count; ++i) {
-        // In a real binding, you would inspect the trampoline's arg types here.
-        // For this example, we'll assume the order int, double, const char*.
-        if (i == 0) { // int
-            int* val_ptr = infix_arena_alloc(call_arena, sizeof(int), _Alignof(int));
-            *val_ptr = va_arg(va, int);
-            args[i] = val_ptr;
-        }
-        else if (i == 1) { // double
-            double* val_ptr = infix_arena_alloc(call_arena, sizeof(double), _Alignof(double));
-            *val_ptr = va_arg(va, double);
-            args[i] = val_ptr;
-        }
-        else if (i == 2) { // const char*
-            const char** val_ptr = infix_arena_alloc(call_arena, sizeof(const char*), _Alignof(const char*));
-            *val_ptr = va_arg(va, const char*);
-            args[i] = val_ptr;
-        }
+        int* val_ptr = infix_arena_alloc(call_arena, sizeof(int), _Alignof(int));
+        *val_ptr = va_arg(va, int); // Get value from dynamic source
+        args[i] = val_ptr;
     }
-    va_end(va);
 
-    // 4. Make the FFI call using the arena-managed data.
-    infix_unbound_cif_func cif = infix_forward_get_unbound_code(trampoline);
-    cif(target_func, NULL, args);
+    // 4. Make the FFI call.
+    infix_forward_get_unbound_code(trampoline)(target_func, NULL, args);
 
     // 5. A single free cleans up the void** array AND all the argument values.
     infix_arena_destroy(call_arena);
 }
-
-void recipe_arena_call_frame() {
-    // Setup the trampoline once and cache it (as a real binding would).
-    const char* signature = "(int, double, *char) -> void";
-    infix_forward_t* trampoline = NULL;
-    infix_forward_create_unbound(&trampoline, signature, NULL);
-
-    printf("Making dynamic FFI call\n");
-    dynamic_ffi_call(trampoline, (void*)process_user_data, 3,
-                     123, 99.8, "test user");
-
-    infix_forward_destroy(trampoline);
-}
 ```
+
+> Full example available in [`Ch08_Rec03_ArenaCallFrame.c`](/eg/cookbook/Ch08_Rec03_ArenaCallFrame.c).
 
 #### How It Works & Why It's Better
 
@@ -2295,9 +1376,6 @@ infix_arena_destroy(loop_arena);
 **Solution**: After a parsing function fails, call `infix_get_last_error()` and use the `position`, `code`, and `message` fields to generate a detailed diagnostic.
 
 ```c
-#include <infix/infix.h>
-#include <stdio.h>
-
 void report_parse_error(const char* signature) {
     infix_type* type = NULL;
     infix_arena_t* arena = NULL;
@@ -2312,25 +1390,14 @@ void report_parse_error(const char* signature) {
         fprintf(stderr, "Error: %s (code: %d, position: %zu)\n",
                 err.message, err.code, err.position);
     }
-    else
-        printf("Successfully parsed signature: %s\n", signature);
-
     infix_arena_destroy(arena);
 }
 
-void recipe_error_reporting() {
-    // This signature has an invalid character '^' instead of a comma.
-    report_parse_error("{int, double, ^*char}");
-}
-
-/*
-Expected output:
-Failed to parse signature:
-  {int, double, ^*char}
-               ^
-Error Code: 200 at position 15
-*/
+// This signature has an invalid character '^' instead of a comma.
+report_parse_error("{int, double, ^*char}");
 ```
+
+> Full example available in [`Ch09_Rec01_ErrorReporting.c`](/eg/cookbook/Ch09_Rec01_ErrorReporting.c).
 
 ### Mistake: Passing a Value Instead of a Pointer in `args[]`
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -6,85 +6,94 @@ This guide provides practical, real-world examples to help you solve common FFI 
 
 ## Table of Contents
 
-   * [Chapter 1: The Basics (Forward Calls)](#chapter-1-the-basics-forward-calls)
-      + [Recipe: Calling a Simple C Function](#recipe-calling-a-simple-c-function)
-      + [Recipe: Passing and Receiving Pointers](#recipe-passing-and-receiving-pointers)
-      + [Recipe: Working with "Out" Parameters](#recipe-working-with-out-parameters)
-      + [Recipe: Working with Opaque Pointers (Incomplete Types)](#recipe-working-with-opaque-pointers-incomplete-types)
-   * [Chapter 2: Handling Complex Data Structures](#chapter-2-handling-complex-data-structures)
-      + [Recipe: Small Structs Passed by Value](#recipe-small-structs-passed-by-value)
-      + [Recipe: Receiving a Struct from a Function](#recipe-receiving-a-struct-from-a-function)
-      + [Recipe: Large Structs Passed by Reference](#recipe-large-structs-passed-by-reference)
-      + [Recipe: Working with Packed Structs](#recipe-working-with-packed-structs)
-      + [Recipe: Working with Structs that Contain Bitfields](#recipe-working-with-structs-that-contain-bitfields)
-      + [Recipe: Working with Unions](#recipe-working-with-unions)
-      + [Recipe: Working with Fixed-Size Arrays](#recipe-working-with-fixed-size-arrays)
-      + [Recipe: Advanced Named Types (Recursive & Forward-Declared)](#recipe-advanced-named-types-recursive--forward-declared)
-      + [Recipe: Working with Complex Numbers](#recipe-working-with-complex-numbers)
-      + [Recipe: Working with SIMD Vectors](#recipe-working-with-simd-vectors)
-      + [Recipe: Working with Enums](#recipe-working-with-enums)
-   * [Chapter 3: The Power of Callbacks (Reverse Calls)](#chapter-3-the-power-of-callbacks-reverse-calls)
-      + [Recipe: Creating a Type-Safe Callback for `qsort`](#recipe-creating-a-type-safe-callback-for-qsort)
-      + [Recipe: Creating a Stateful Callback](#recipe-creating-a-stateful-callback)
-   * [Chapter 4: Advanced Techniques](#chapter-4-advanced-techniques)
-      + [Recipe: Calling Variadic Functions like `printf`](#recipe-calling-variadic-functions-like-printf)
-      + [Recipe: Receiving and Calling a Function Pointer](#recipe-receiving-and-calling-a-function-pointer)
-      + [Recipe: Calling a Function Pointer from a Struct (V-Table Emulation)](#recipe-calling-a-function-pointer-from-a-struct-v-table-emulation)
-      + [Recipe: Handling `longdouble`](#recipe-handling-longdouble)
-      + [Recipe: Proving Reentrancy with Nested FFI Calls](#recipe-proving-reentrancy-with-nested-ffi-calls)
-      + [Recipe: Proving Thread Safety](#recipe-proving-thread-safety)
-   * [Chapter 5: Interoperability with Other Languages](#chapter-5-interoperability-with-other-languages)
-      + [The Universal Principle: The C ABI](#the-universal-principle-the-c-abi)
-      + [Recipe: Interfacing with a C++ Class (Directly)](#recipe-interfacing-with-a-c-class-directly)
-      + [Recipe: Interfacing with C++ Templates](#recipe-interfacing-with-c-templates)
-      + [The Pattern for Other Compiled Languages](#the-pattern-for-other-compiled-languages)
-         - [Rust](#rust)
-         - [Zig](#zig)
-         - [Go](#go)
-         - [Swift](#swift)
-         - [Dlang](#dlang)
-         - [Fortran](#fortran)
-         - [Assembly](#assembly)
-   * [Chapter 6: Dynamic Libraries & System Calls](#chapter-6-dynamic-libraries--system-calls)
-      + [Recipe: Calling Native System Libraries without Linking](#recipe-calling-native-system-libraries-without-linking)
-      + [Recipe: Reading and Writing Global Variables](#recipe-reading-and-writing-global-variables)
-         - [Example 1: Simple Integer Variable](#example-1-simple-integer-variable)
-         - [Example 2: Aggregate (Struct) Variable](#example-2-aggregate-struct-variable)
-      + [Recipe: Handling Library Dependencies](#recipe-handling-library-dependencies)
-   * [Chapter 7: Introspection for Data Marshalling](#chapter-7-introspection-for-data-marshalling)
-      + [Recipe: Dynamic Struct Marshalling with the Signature Parser](#recipe-dynamic-struct-marshalling-with-the-signature-parser)
-      + [Recipe: Building a Signature String at Runtime](#recipe-building-a-signature-string-at-runtime)
-      + [Recipe: Introspecting a Trampoline for a Wrapper](#recipe-introspecting-a-trampoline-for-a-wrapper)
-   * [Chapter 8: Performance & Memory Management](#chapter-8-performance--memory-management)
-      + [Best Practice: Caching Trampolines](#best-practice-caching-trampolines)
-      + [Recipe: Using a Custom Arena for a Group of Types](#recipe-using-a-custom-arena-for-a-group-of-types)
-      + [Recipe: The Full Manual API Lifecycle (Types to Trampoline)](#recipe-the-full-manual-api-lifecycle-types-to-trampoline)
-      + [Recipe: Using Custom Memory Allocators](#recipe-using-custom-memory-allocators)
-      + [Recipe: Building a Dynamic Call Frame with an Arena](#recipe-building-a-dynamic-call-frame-with-an-arena)
-         - [How It Works & Why It's Better](#how-it-works--why-its-better)
-         - [Advanced Optimization: Arena Resetting for Hot Loops](#advanced-optimization-arena-resetting-for-hot-loops)
-   * [Chapter 9: Common Pitfalls & Troubleshooting](#chapter-9-common-pitfalls--troubleshooting)
-      + [Recipe: Advanced Error Reporting for the Parser](#recipe-advanced-error-reporting-for-the-parser)
-      + [Mistake: Passing a Value Instead of a Pointer in `args[]`](#mistake-passing-a-value-instead-of-a-pointer-in-args)
-      + [Mistake: `infix` Signature Mismatch](#mistake-infix-signature-mismatch)
-      + [Pitfall: Function Pointer Syntax](#pitfall-function-pointer-syntax)
-   * [Chapter 10: A Comparative Look: `infix` vs. `libffi` and `dyncall`](#chapter-10-a-comparative-look-infix-vs-libffi-and-dyncall)
-      + [Scenario 1: Calling a Simple Function](#scenario-1-calling-a-simple-function)
-         - [The `dyncall` Approach](#the-dyncall-approach)
-         - [The `libffi` Approach](#the-libffi-approach)
-         - [The `infix` Approach](#the-infix-approach)
-      + [Scenario 2: Calling a Function with a Struct](#scenario-2-calling-a-function-with-a-struct)
-         - [The `dyncall` Approach](#the-dyncall-approach-1)
-         - [The `libffi` Approach](#the-libffi-approach-1)
-         - [The `infix` Approach](#the-infix-approach-1)
-      + [Scenario 3: Creating a Callback](#scenario-3-creating-a-callback)
-         - [The `dyncall` Approach](#the-dyncall-approach-2)
-         - [The `libffi` Approach](#the-libffi-approach-2)
-         - [The `infix` Approach](#the-infix-approach-2)
-      + [Analysis and Takeaways](#analysis-and-takeaways)
-   * [Chapter 11: Building Language Bindings](#chapter-11-building-language-bindings)
-      + [The Four Pillars of a Language Binding](#the-four-pillars-of-a-language-binding)
-      + [Recipe: Porting a Python Binding from `dyncall` to `infix`](#recipe-porting-a-python-binding-from-dyncall-to-infix)
+* [Chapter 1: The Basics (Forward Calls)](#chapter-1-the-basics-forward-calls)
+    + [Recipe: Calling a Simple C Function](#recipe-calling-a-simple-c-function)
+    + [Recipe: Passing and Receiving Pointers](#recipe-passing-and-receiving-pointers)
+    + [Recipe: Working with "Out" Parameters](#recipe-working-with-out-parameters)
+    + [Recipe: Working with Opaque Pointers (Incomplete Types)](#recipe-working-with-opaque-pointers-incomplete-types)
+* [Chapter 2: Handling Complex Data Structures](#chapter-2-handling-complex-data-structures)
+    + [Recipe: Small Structs Passed by Value](#recipe-small-structs-passed-by-value)
+    + [Recipe: Receiving a Struct from a Function](#recipe-receiving-a-struct-from-a-function)
+    + [Recipe: Large Structs Passed by Reference](#recipe-large-structs-passed-by-reference)
+    + [Recipe: Working with Packed Structs](#recipe-working-with-packed-structs)
+    + [Recipe: Working with Structs that Contain Bitfields](#recipe-working-with-structs-that-contain-bitfields)
+    + [Recipe: Working with Unions](#recipe-working-with-unions)
+    + [Recipe: Working with Fixed-Size Arrays](#recipe-working-with-fixedsize-arrays)
+    + [Recipe: Advanced Named Types (Recursive & Forward-Declared)](#recipe-advanced-named-types-recursive-amp-forwarddeclared)
+    + [Recipe: Working with Complex Numbers](#recipe-working-with-complex-numbers)
+    + [Recipe: Working with SIMD Vectors](#recipe-working-with-simd-vectors)
+        - [x86-64 (SSE, AVX, and AVX-512)](#x8664-sse-avx-and-avx512)
+        - [AArch64 (NEON)](#aarch64-neon)
+        - [AArch64 (Scalable Vector Extension - SVE)](#aarch64-scalable-vector-extension--sve)
+    + [Recipe: Working with Enums](#recipe-working-with-enums)
+* [Chapter 3: The Power of Callbacks (Reverse Calls)](#chapter-3-the-power-of-callbacks-reverse-calls)
+    + [Recipe: Creating a Type-Safe Callback for `qsort`](#recipe-creating-a-typesafe-callback-for--raw-qsort-endraw-)
+    + [Recipe: Creating a Stateful Callback](#recipe-creating-a-stateful-callback)
+* [Chapter 4: Advanced Techniques](#chapter-4-advanced-techniques)
+    + [Recipe: Calling Variadic Functions like `printf`](#recipe-calling-variadic-functions-like--raw-printf-endraw-)
+    + [Recipe: Receiving and Calling a Function Pointer](#recipe-receiving-and-calling-a-function-pointer)
+    + [Recipe: Calling a Function Pointer from a Struct (V-Table Emulation)](#recipe-calling-a-function-pointer-from-a-struct-vtable-emulation)
+    + [Recipe: Handling `longdouble`](#recipe-handling--raw-longdouble-endraw-)
+    + [Recipe: Proving Reentrancy with Nested FFI Calls](#recipe-proving-reentrancy-with-nested-ffi-calls)
+    + [Recipe: Proving Thread Safety](#recipe-proving-thread-safety)
+* [Chapter 5: Interoperability with Other Languages](#chapter-5-interoperability-with-other-languages)
+    + [The Universal Principle: The C ABI](#the-universal-principle-the-c-abi)
+    + [Recipe: Interfacing with a C++ Class (Directly)](#recipe-interfacing-with-a-c-class-directly)
+    + [Recipe: Interfacing with C++ Templates](#recipe-interfacing-with-c-templates)
+    + [The Pattern for Other Compiled Languages](#the-pattern-for-other-compiled-languages)
+        - [Rust](#rust)
+        - [Zig](#zig)
+        - [Go](#go)
+        - [Swift](#swift)
+        - [Dlang](#dlang)
+        - [Fortran](#fortran)
+        - [Assembly](#assembly)
+    + [Recipe: Handling Strings and Semantic Types (`wchar_t`, etc.)](#recipe-handling-strings-and-semantic-types--raw-wchart-endraw--etc)
+        - [Step 1: Define Semantic Aliases in a Registry](#step-1-define-semantic-aliases-in-a-registry)
+        - [Step 2: Use the Aliases in Your Signature](#step-2-use-the-aliases-in-your-signature)
+        - [Step 3: Introspect with Semantic Awareness](#step-3-introspect-with-semantic-awareness)
+    + [Recipe: Calling C++ Virtual Functions (V-Table Emulation)](#recipe-calling-c-virtual-functions-vtable-emulation)
+    + [Recipe: Bridging C++ Callbacks (`std::function`) and Lambdas](#recipe-bridging-c-callbacks--raw-stdfunction-endraw--and-lambdas)
+* [Chapter 6: Dynamic Libraries & System Calls](#chapter-6-dynamic-libraries-amp-system-calls)
+    + [Recipe: Calling Native System Libraries without Linking](#recipe-calling-native-system-libraries-without-linking)
+    + [Recipe: Reading and Writing Global Variables](#recipe-reading-and-writing-global-variables)
+        - [Example 1: Simple Integer Variable](#example-1-simple-integer-variable)
+        - [Example 2: Aggregate (Struct) Variable](#example-2-aggregate-struct-variable)
+    + [Recipe: Handling Library Dependencies](#recipe-handling-library-dependencies)
+* [Chapter 7: Introspection for Data Marshalling](#chapter-7-introspection-for-data-marshalling)
+    + [Recipe: Dynamic Struct Marshalling with the Signature Parser](#recipe-dynamic-struct-marshalling-with-the-signature-parser)
+    + [Recipe: Building a Signature String at Runtime](#recipe-building-a-signature-string-at-runtime)
+    + [Recipe: Introspecting a Trampoline for a Wrapper](#recipe-introspecting-a-trampoline-for-a-wrapper)
+* [Chapter 8: Performance & Memory Management](#chapter-8-performance-amp-memory-management)
+    + [Best Practice: Caching Trampolines](#best-practice-caching-trampolines)
+    + [Recipe: Using a Custom Arena for a Group of Types](#recipe-using-a-custom-arena-for-a-group-of-types)
+    + [Recipe: The Full Manual API Lifecycle (Types to Trampoline)](#recipe-the-full-manual-api-lifecycle-types-to-trampoline)
+    + [Recipe: Using Custom Memory Allocators](#recipe-using-custom-memory-allocators)
+    + [Recipe: Building a Dynamic Call Frame with an Arena](#recipe-building-a-dynamic-call-frame-with-an-arena)
+        - [How It Works & Why It's Better](#how-it-works-amp-why-its-better)
+        - [Advanced Optimization: Arena Resetting for Hot Loops](#advanced-optimization-arena-resetting-for-hot-loops)
+* [Chapter 9: Common Pitfalls & Troubleshooting](#chapter-9-common-pitfalls-amp-troubleshooting)
+    + [Recipe: Advanced Error Reporting for the Parser](#recipe-advanced-error-reporting-for-the-parser)
+    + [Mistake: Passing a Value Instead of a Pointer in `args[]`](#mistake-passing-a-value-instead-of-a-pointer-in--raw-args-endraw-)
+    + [Mistake: `infix` Signature Mismatch](#mistake--raw-infix-endraw--signature-mismatch)
+    + [Pitfall: Function Pointer Syntax](#pitfall-function-pointer-syntax)
+* [Chapter 10: A Comparative Look: `infix` vs. `libffi` and `dyncall`](#chapter-10-a-comparative-look--raw-infix-endraw--vs--raw-libffi-endraw--and--raw-dyncall-endraw-)
+    + [Scenario 1: Calling a Simple Function](#scenario-1-calling-a-simple-function)
+        - [The `dyncall` Approach](#the--raw-dyncall-endraw--approach)
+        - [The `libffi` Approach](#the--raw-libffi-endraw--approach)
+        - [The `infix` Approach](#the--raw-infix-endraw--approach)
+    + [Scenario 2: Calling a Function with a Struct](#scenario-2-calling-a-function-with-a-struct)
+        - [The `dyncall` Approach](#the--raw-dyncall-endraw--approach-1)
+        - [The `libffi` Approach](#the--raw-libffi-endraw--approach-1)
+        - [The `infix` Approach](#the--raw-infix-endraw--approach-1)
+    + [Scenario 3: Creating a Callback](#scenario-3-creating-a-callback)
+        - [The `dyncall` Approach](#the--raw-dyncall-endraw--approach-2)
+        - [The `libffi` Approach](#the--raw-libffi-endraw--approach-2)
+        - [The `infix` Approach](#the--raw-infix-endraw--approach-2)
+    + [Analysis and Takeaways](#analysis-and-takeaways)
+* [Chapter 11: Building Language Bindings](#chapter-11-building-language-bindings)
+    + [The Four Pillars of a Language Binding](#the-four-pillars-of-a-language-binding)
+    + [Recipe: Porting a Python Binding from `dyncall` to `infix`](#recipe-porting-a-python-binding-from--raw-dyncall-endraw--to--raw-infix-endraw-)
 
 ---
 
@@ -1123,6 +1132,8 @@ void recipe_thread_safety() {
 
 ## Chapter 5: Interoperability with Other Languages
 
+While `infix` can call any function with a C ABI, its true power shines when tackling complex interoperability challenges with more advanced languages like C++ and Rust. This chapter provides recipes for interfacing with other languages and with language features that don't have a direct C equivalent, such as virtual functions and stateful lambdas from C++.
+
 ### The Universal Principle: The C ABI
 
 `infix` can call any function that exposes a standard C ABI. Nearly every compiled language provides a mechanism to export a function using this standard (`extern "C"` in C++/Rust/Zig, `//export` in Go, `bind(C)` in Fortran).
@@ -1374,6 +1385,288 @@ asm_add:
 
 *Compile with: `nasm -f elf64 libasm_math.asm && gcc -shared -o libasm_math.so libasm_math.o`*
 
+### Recipe: Handling Strings and Semantic Types (`wchar_t`, etc.)
+
+**Problem**: You are building a language binding and need to introspect a signature to marshal strings correctly. A signature like `*uint16` is structurally correct for a Windows `wchar_t*`, but how does your code know it's a null-terminated string and not just a pointer to an integer?
+
+**Solution**: Use the `infix` type registry to create **semantic aliases**. The signature string itself can then document the *intent* of the type, which your wrapper can use to trigger the correct string-handling logic. This pattern provides the missing link between C's structural type system and the semantic needs of a high-level language.
+
+Let's model the Windows `MessageBoxW` function, which takes two UTF-16 strings.
+
+#### Step 1: Define Semantic Aliases in a Registry
+
+Create a registry that defines aliases whose names convey meaning. These aliases still map to the correct underlying C types, but their names provide the context needed for introspection.
+
+```c
+#include <infix/infix.h>
+
+void recipe_semantic_string_types() {
+    infix_registry_t* registry = infix_registry_create();
+
+    const char* string_types =
+        // Structural aliases for Windows types
+        "@HWND = *void;"
+        "@UINT = uint32;"
+
+        // Semantic aliases that describe intent, not just structure.
+        // We define them as structs so their names are preserved after resolution.
+        "@UTF16String = { data: *uint16 };" // Represents wchar_t* on Windows
+        "@UTF8String = { data: *char };"    // Represents const char*
+    ;
+    infix_register_types(registry, string_types);
+
+    // ... use the registry ...
+
+    infix_registry_destroy(registry);
+}
+```
+
+> **Note:** We define `UTF16String` as `{*uint16}` instead of a direct alias `*uint16`. This is a crucial technique. By wrapping the pointer in a struct, the name `@UTF16String` refers to the struct itself. After resolution, the `.name` field is preserved on the struct type, making introspection possible.
+
+#### Step 2: Use the Aliases in Your Signature
+
+The signature for `MessageBoxW` now becomes self-documenting and machine-readable.
+
+```c
+// Signature for: int MessageBoxW(HWND hwnd, LPCWSTR lpText, LPCWSTR lpCaption, UINT uType);
+const char* signature = "(@HWND, @UTF16String, @UTF16String, @UINT) -> int";
+```
+
+#### Step 3: Introspect with Semantic Awareness
+
+Your language binding can now parse this signature and make intelligent decisions. The key is to check the **name of the resolved aggregate type**.
+
+**Conceptual Wrapper Introspection Logic:**
+
+```c
+// 1. Parse the function signature with the registry.
+infix_signature_parse(signature, &arena, &ret, &args, &num_args, &num_fixed, registry);
+
+// 2. Introspect the type of the second argument (index 1).
+const infix_type* arg_type = args[1].type;
+
+// 3. After resolution, `@UTF16String` is a STRUCT. Check its preserved name.
+if (arg_type->category == INFIX_TYPE_STRUCT && arg_type->meta.aggregate_info.name != NULL) {
+    const char* type_name = arg_type->meta.aggregate_info.name;
+
+    // 4. Check the semantic name.
+    if (strcmp(type_name, "UTF16String") == 0) {
+        // This is our cue! Marshal the user's string as UTF-16.
+
+        // We can further introspect the struct's members to confirm the underlying type.
+        const infix_struct_member* member = infix_type_get_member(arg_type, 0);
+        const infix_type* pointer_type = member->type;
+        const infix_type* pointee_type = pointer_type->meta.pointer_info.pointee_type;
+
+        // assert(pointee_type->size == 2); // It's a 16-bit character.
+    }
+    else if (strcmp(type_name, "UTF8String") == 0) {
+        // Marshal as UTF-8.
+    }
+}
+```
+
+This pattern is the recommended approach. It keeps the core `infix` signature language focused on describing the C ABI accurately, while leveraging the type registry to provide the rich semantic information that high-level language bindings need.
+
+### Recipe: Calling C++ Virtual Functions (V-Table Emulation)
+
+**Problem**: You have a pointer to a C++ polymorphic base class object (e.g., `Shape*`) and you need to call a `virtual` function on it from C, achieving true dynamic dispatch.
+
+**Solution**: Emulate what the C++ compiler does: manually read the object's v-table pointer (`vptr`), find the function pointer at the correct index within the v-table, and use `infix` to call it.
+
+First, the C++ library (`shapes.cpp`):
+
+```cpp
+// File: shapes.cpp (compile to libshapes.so/.dll)
+#include <cmath>
+
+class Shape {
+public:
+    virtual double area() const = 0; // 1st virtual function (index 0)
+    virtual const char* name() const = 0; // 2nd virtual function (index 1)
+    virtual ~Shape() = default;
+};
+
+class Rectangle : public Shape {
+    double w, h;
+public:
+    Rectangle(double width, double height) : w(width), h(height) {}
+    double area() const override { return w * h; }
+    const char* name() const override { return "Rectangle"; }
+};
+
+// extern "C" factory functions to create objects.
+extern "C" Shape* create_rectangle(double w, double h) { return new Rectangle(w, h); }
+extern "C" void destroy_shape(Shape* s) { delete s; }
+```
+
+Now, the C code using `infix` to call the `virtual` methods:
+
+```c
+#include <infix/infix.h>
+#include <stdio.h>
+
+void recipe_virtual_functions() {
+    infix_library_t* lib = infix_library_open("./libshapes.so");
+    if (!lib) return;
+
+    // 1. Get the factory functions.
+    void* (*create_rectangle)(double, double) = infix_library_get_symbol(lib, "create_rectangle");
+    void (*destroy_shape)(void*) = infix_library_get_symbol(lib, "destroy_shape");
+
+    // 2. Create a C++ object and treat it as an opaque pointer.
+    void* rect_obj = create_rectangle(10.0, 5.0);
+
+    // 3. Manually read the v-table.
+    // The v-pointer is at the start of the object's memory.
+    void** vptr = (void**)rect_obj;
+    void** vtable = *vptr;
+
+    // 4. Read the function pointers from the v-table.
+    // The order matches the declaration order in the class.
+    void* area_fn_ptr = vtable[0]; // pointer to Rectangle::area()
+    void* name_fn_ptr = vtable[1]; // pointer to Rectangle::name()
+
+    // 5. Create trampolines for the discovered function pointers.
+    // Signature for double area(const Shape* this): "(*void)->double"
+    // Signature for const char* name(const Shape* this): "(*void)->*char"
+    infix_forward_t *t_area, *t_name;
+    infix_forward_create(&t_area, "(*void)->double", area_fn_ptr, NULL);
+    infix_forward_create(&t_name, "(*void)->*char", name_fn_ptr, NULL);
+
+    // 6. Call the virtual functions, passing the object as the 'this' pointer.
+    double rect_area;
+    const char* rect_name;
+    infix_forward_get_code(t_area)(&rect_area, &rect_obj);
+    infix_forward_get_code(t_name)(&rect_name, &rect_obj);
+
+    printf("Object '%s' has virtual area(): %f\n", rect_name, rect_area); // Expected: Rectangle, 50.0
+
+    // 7. Clean up.
+    destroy_shape(rect_obj);
+    infix_forward_destroy(t_area);
+    infix_forward_destroy(t_name);
+    infix_library_close(lib);
+}
+```
+
+### Recipe: Bridging C++ Callbacks (`std::function`) and Lambdas
+
+**Problem**: You need to call a C++ method that accepts a callback (e.g., `std::function<void(int)>`), and provide a stateful handler from your C application.
+
+**Solution**: This is a powerful, two-way FFI interaction. You will create an `infix` closure to represent your C-side state, and then call a mangled C++ method to register that closure's components (its C function pointer and its state pointer) with the C++ object.
+
+First, the C++ library that takes a callback:
+
+```cpp
+// File: EventManager.cpp (compile to libeventmanager.so/.dll)
+#include <functional>
+#include <iostream>
+
+class EventManager {
+    // We store the C-style callback parts.
+    void (*handler_ptr)(int, void*);
+    void* user_data;
+public:
+    EventManager() : handler_ptr(nullptr), user_data(nullptr) {
+        std::cout << "C++ EventManager constructed.\n";
+    }
+    // A method to register a C-style callback.
+    void set_handler(void (*h)(int, void*), void* data) {
+        this->handler_ptr = h;
+        this->user_data = data;
+    }
+    // A method to trigger the stored callback.
+    void trigger(int value) {
+        if (handler_ptr) {
+            std::cout << "C++ is triggering the callback with value " << value << "...\n";
+            handler_ptr(value, user_data);
+        }
+    }
+};
+```
+
+Now, the C application that provides a stateful callback to the `EventManager` object:
+
+```c
+#include <infix/infix.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// On GCC/Clang, find these with: nm -C libeventmanager.so | grep EventManager
+const char* MANGLED_CTOR = "_ZN12EventManagerC1Ev";
+const char* MANGLED_SET_HANDLER = "_ZN12EventManager10set_handlerEPFviPvES_";
+const char* MANGLED_TRIGGER = "_ZN12EventManager7triggerEi";
+
+// Our C application's state and the generic handler for our infix closure.
+typedef struct { int call_count; } C_AppState;
+
+void my_closure_handler(infix_context_t* context, void* ret, void** args) {
+    (void)ret;
+    C_AppState* state = (C_AppState*)infix_reverse_get_user_data(context);
+    state->call_count++;
+
+    int value_from_cpp = *(int*)args[0];
+    printf("C handler called (invocation #%d)! Received value: %d\n", state->call_count, value_from_cpp);
+}
+
+void recipe_cpp_callback() {
+    infix_library_t* lib = infix_library_get_symbol(lib, "libeventmanager.so");
+    if(!lib) return;
+
+    // 1. Get pointers to the mangled C++ methods.
+    void* p_ctor = infix_library_get_symbol(lib, MANGLED_CTOR);
+    void* p_set_handler = infix_library_get_symbol(lib, MANGLED_SET_HANDLER);
+    void* p_trigger = infix_library_get_symbol(lib, MANGLED_TRIGGER);
+
+    // 2. Create the C-side state and the infix closure.
+    C_AppState app_state = {0};
+    infix_reverse_t* closure = NULL;
+    infix_reverse_create_closure(&closure, "(int, *void)->void", my_closure_handler, &app_state, NULL);
+
+    // 3. Create an instance of the C++ EventManager object.
+    // Constructor signature: void EventManager(EventManager* this);
+    void* manager_obj = malloc(sizeof(void*)*2); // Allocate space for the object.
+    infix_forward_t* t_ctor;
+    infix_forward_create(&t_ctor, "(*void)->void", p_ctor, NULL);
+    infix_forward_get_code(t_ctor)(NULL, &manager_obj);
+
+    // 4. Call the set_handler method to register our closure.
+    // Signature: void set_handler(EventManager* this, void (*h)(int, void*), void* data);
+    // Becomes: "(*void, *(*(...)), *void) -> void"
+    infix_forward_t* t_set_handler;
+    infix_forward_create(&t_set_handler, "(*void, *((*void)->void), *void)->void", p_set_handler, NULL);
+
+    void* closure_c_func = infix_reverse_get_code(closure);
+    void* closure_user_data = infix_reverse_get_user_data(closure);
+    void* set_handler_args[] = { &manager_obj, &closure_c_func, &closure_user_data };
+    infix_forward_get_code(t_set_handler)(NULL, set_handler_args);
+
+    // 5. Call the trigger method to make the C++ object invoke our callback.
+    // Signature: void trigger(EventManager* this, int value);
+    infix_forward_t* t_trigger;
+    infix_forward_create(&t_trigger, "(*void, int)->void", p_trigger, NULL);
+
+    int value_to_send = 42;
+    void* trigger_args[] = { &manager_obj, &value_to_send };
+    infix_forward_get_code(t_trigger)(NULL, trigger_args); // First call
+
+    value_to_send = 99;
+    infix_forward_get_code(t_trigger)(NULL, trigger_args); // Second call
+
+    printf("Final C-side call count: %d\n", app_state.call_count); // Expected: 2
+
+    // 6. Clean up.
+    // Note: The destructor would need to be called here in a real application.
+    free(manager_obj);
+    infix_forward_destroy(t_ctor);
+    infix_forward_destroy(t_set_handler);
+    infix_forward_destroy(t_trigger);
+    infix_reverse_destroy(closure);
+    infix_library_close(lib);
+}
+```
+
 ## Chapter 6: Dynamic Libraries & System Calls
 
 ### Recipe: Calling Native System Libraries without Linking
@@ -1381,6 +1674,11 @@ asm_add:
 **Problem**: You need to call a function from a system library (e.g., `user32.dll`) without linking against its import library at compile time.
 
 **Solution**: Use `infix`'s cross-platform library loading API to get a handle to the library and the function pointer, then create a trampoline.
+
+> **Finding Mangled Names**
+> This recipe relies on finding the "mangled" or "decorated" names that the C++ compiler generates for functions. You can find these names using your platform's tools:
+> - Linux/macOS: `nm -C mylibrary.so` or `readelf -sW mylibrary.so`
+> - Windows: `dumpbin /SYMBOLS mylibrary.dll` or `nm -C mylibrary.dll`
 
 ```c
 #include <infix/infix.h>

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -197,8 +197,15 @@ void recipe_out_parameters() {
     double score = 0.0;
     bool success;
 
-    // The args array contains pointers to our local variables.
-    void* args[] = { &user_id, &post_count, &score };
+    int * p_post_count = &post_count;
+    double * p_score = &score;
+
+    // The `args` array contains pointers to our arguments' values.
+    void * args[] = {
+        &user_id,
+        &p_post_count,
+        &p_score
+    };
 
     infix_forward_get_code(t)(&success, args);
 

--- a/docs/signatures.md
+++ b/docs/signatures.md
@@ -40,13 +40,15 @@ These keywords represent standard C types whose size can vary by platform. They 
 | `ushort`        | `unsigned short`     | 16 bits             | An unsigned integer of at least 16 bits.                                    |
 | `int`           | `int`                | 32 bits             | The platform's native signed integer, usually 32 bits.                      |
 | `uint`          | `unsigned int`       | 32 bits             | The platform's native unsigned integer.                                     |
-| `long`          | `long`               | **32 or 64 bits**   | **Platform-dependent.** 32 bits on 64-bit Windows, 64 bits on Linux/macOS.  |
-| `ulong`         | `unsigned long`      | **32 or 64 bits**   | The unsigned version of `long`.                                             |
+| `long`          | `long`               | 32 or 64 bits       | **Platform-dependent.** 32 bits on 64-bit Windows, 64 bits on Linux/macOS.  |
+| `ulong`         | `unsigned long`      | 32 or 64 bits       | The unsigned version of `long`.                                             |
 | `longlong`      | `long long`          | 64 bits             | A signed integer of at least 64 bits.                                       |
 | `ulonglong`     | `unsigned long long` | 64 bits             | An unsigned integer of at least 64 bits.                                    |
 | `float`         | `float`              | 32 bits             | A 32-bit single-precision floating-point number.                            |
 | `double`        | `double`             | 64 bits             | A 64-bit double-precision floating-point number.                            |
-| `longdouble`    | `long double`        | **Varies**          | 80-bit (x86), 128-bit (AArch64), or 64-bit (MSVC) float. Use with caution.  |
+| `longdouble`    | `long double`        | Varies              | 80-bit (x86), 128-bit (AArch64), or 64-bit (MSVC) float. Use with caution.  |
+| `size_t`        | `size_t`             | 32 or 64 bits       | **Platform-dependent.** 32 bits on 64-bit Windows, 64 bits on Linux/macOS.  |
+| `ssize_t`       | `ssize_t`            | 32 or 64 bits       | **Platform-dependent.** 32 bits on 64-bit Windows, 64 bits on Linux/macOS.  |
 
 #### Tier 2: Explicit Fixed-Width Types (Recommended)
 
@@ -61,6 +63,9 @@ For maximum portability and control, these keywords guarantee the size of the ty
 | `sint128`, `uint128`  | `__int128_t`          | 128 bits | 128-bit integers (GCC/Clang extension).           |
 | `float32`             | `float`               | 32 bits  | An explicit alias for a 32-bit float.             |
 | `float64`             | `double`              | 64 bits  | An explicit alias for a 64-bit float.             |
+| `char8_t`             | `char8_t`             | 8 bits   | An explicit alias for an 8-bit unsigned integer (UTF-8 character unit).  |
+| `char16_t`            | `char16_t`            | 16 bits  | An explicit alias for a 16-bit unsigned integer (UTF-16 character unit). |
+| `char32_t`            | `char32_t`            | 32 bits  | An explicit alias for a 32-bit unsigned integer (UTF-32 character unit). |
 
 #### Tier 3: SIMD Vector Aliases
 

--- a/eg/cookbook/Ch01_Rec01_SimpleCall.c
+++ b/eg/cookbook/Ch01_Rec01_SimpleCall.c
@@ -1,0 +1,49 @@
+/**
+ * @file Ch01_Rec01_SimpleCall.c
+ * @brief Cookbook Chapter 1, Recipe 1: Calling a Simple C Function
+ *
+ * This example demonstrates the most fundamental use of infix: calling a standard
+ * C library function (`atan2`) that takes two `double` arguments and returns a
+ * `double`. It uses an "unbound" trampoline, which is flexible and can be used
+ * to call any function matching the specified signature.
+ */
+#include <infix/infix.h>
+#include <math.h>
+#include <stdio.h>
+
+int main() {
+    printf("--- Cookbook Chapter 1, Recipe 1: Calling a Simple C Function ---\n");
+
+    // 1. Describe the signature of the function we want to call:
+    //    double atan2(double y, double x);
+    const char * signature = "(double, double) -> double";
+
+    // 2. Create an unbound trampoline. The function to call is not specified yet.
+    infix_forward_t * trampoline = NULL;
+    infix_status status = infix_forward_create_unbound(&trampoline, signature, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create unbound trampoline.\n");
+        return 1;
+    }
+
+    // 3. Get the callable function pointer from the trampoline.
+    infix_unbound_cif_func cif = infix_forward_get_unbound_code(trampoline);
+
+    // 4. Prepare arguments and a buffer for the return value.
+    //    The `args` array must hold *pointers* to the argument values.
+    double y = 1.0, x = 1.0;
+    void * args[] = {&y, &x};
+    double result;
+
+    // 5. Invoke the call. For an unbound trampoline, the target function
+    //    (`atan2` in this case) is passed as the first argument.
+    cif((void *)atan2, &result, args);
+
+    printf("Calling atan2(1.0, 1.0) via infix...\n");
+    printf("Result: %f (Expected: ~0.785, which is PI/4)\n", result);
+
+    // 6. Clean up the trampoline.
+    infix_forward_destroy(trampoline);
+
+    return 0;
+}

--- a/eg/cookbook/Ch01_Rec02_Pointers.c
+++ b/eg/cookbook/Ch01_Rec02_Pointers.c
@@ -1,0 +1,52 @@
+/**
+ * @file Ch01_Rec02_Pointers.c
+ * @brief Cookbook Chapter 1, Recipe 2: Passing and Receiving Pointers
+ *
+ * This example demonstrates how to call a C function that takes a pointer as an
+ * argument and also returns a pointer. It uses the standard library function
+ * `strchr`. The signature `*char` represents a pointer to a character.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+    printf("--- Cookbook Chapter 1, Recipe 2: Passing and Receiving Pointers ---\n");
+
+    // 1. Describe the signature for: const char* strchr(const char* s, int c);
+    //    Note that `const char*` becomes `*char` and `int` is used for the character.
+    const char * signature = "(*char, int) -> *char";
+
+    // 2. Create a "bound" trampoline, which is optimized for calling a single
+    //    specific function. The address of `strchr` is compiled into it.
+    infix_forward_t * trampoline = NULL;
+    infix_status status = infix_forward_create(&trampoline, signature, (void *)strchr, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create bound trampoline.\n");
+        return 1;
+    }
+
+    // 3. Get the callable function pointer.
+    infix_cif_func cif = infix_forward_get_code(trampoline);
+
+    // 4. Prepare arguments. The value for the `*char` argument is the
+    //    address of our `const char*` variable.
+    const char * haystack = "hello-world";
+    int needle = '-';
+    void * args[] = {&haystack, &needle};
+    const char * result_ptr = NULL;  // Buffer for the returned pointer.
+
+    // 5. Invoke the call.
+    cif(&result_ptr, args);
+
+    printf("Calling strchr(\"hello-world\", '-') via infix...\n");
+    if (result_ptr)
+        printf("strchr found substring: '%s'\n", result_ptr);  // Expected: "-world"
+    else
+        printf("strchr did not find the character.\n");
+
+    // 6. Clean up.
+    infix_forward_destroy(trampoline);
+
+    return 0;
+}

--- a/eg/cookbook/Ch01_Rec03_OutParameters.c
+++ b/eg/cookbook/Ch01_Rec03_OutParameters.c
@@ -1,0 +1,81 @@
+/**
+ * @file Ch01_Rec03_OutParameters.c
+ * @brief Cookbook Chapter 1, Recipe 3: Working with "Out" Parameters
+ *
+ * This example demonstrates a very common C pattern where a function returns
+ * its primary output via a pointer argument (an "out" parameter) rather than
+ * its direct return value. The signature simply represents this as a pointer
+ * type (e.g., `*int`).
+ */
+#include <infix/infix.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+// The native C function we want to call.
+// It returns a status code and writes its main results to the pointer arguments.
+static bool get_user_stats(int user_id, int * out_posts, double * out_score) {
+    if (user_id == 123) {
+        if (out_posts)
+            *out_posts = 50;
+        if (out_score)
+            *out_score = 99.8;
+        return true;
+    }
+    return false;
+}
+
+int main() {
+    printf("--- Cookbook Chapter 1, Recipe 3: Working with \"Out\" Parameters ---\n");
+
+    // 1. Signature for: bool get_user_stats(int, int*, double*);
+    const char * signature = "(int, *int, *double) -> bool";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)get_user_stats, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Prepare arguments. The "out" parameters start as local variables.
+    int user_id = 123;
+    int post_count = 0;
+    double score = 0.0;
+    bool success;
+
+    // 4. For "out" parameters (which are pointers), we must create local
+    //    variables to hold those pointers. The `args` array will then
+    //    contain pointers TO those pointer variables.
+
+    // Value for arg 1 is the integer `user_id`.
+    // Value for arg 2 is the pointer `&post_count`.
+    // Value for arg 3 is the pointer `&score`.
+    int * p_post_count = &post_count;
+    double * p_score = &score;
+
+    // The `args` array contains pointers to our arguments' values.
+    void * args[] = {
+        &user_id,       // Pointer to the int value
+        &p_post_count,  // Pointer to the int* value
+        &p_score        // Pointer to the double* value
+    };
+
+    // 5. Call the function.
+    cif(&success, args);
+
+    printf("Calling get_user_stats for user ID 123...\n");
+    if (success) {
+        printf("Function succeeded. User stats retrieved:\n");
+        printf("  Post Count: %d (Expected: 50)\n", post_count);
+        printf("  Score: %.1f (Expected: 99.8)\n", score);
+    }
+    else
+        printf("Function failed.\n");
+
+    // 6. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}

--- a/eg/cookbook/Ch01_Rec04_OpaquePointers.c
+++ b/eg/cookbook/Ch01_Rec04_OpaquePointers.c
@@ -1,0 +1,78 @@
+/**
+ * @file Ch01_Rec04_OpaquePointers.c
+ * @brief Cookbook Chapter 1, Recipe 4: Working with Opaque Pointers
+ *
+ * This example shows how to interact with C libraries that use opaque pointers
+ * or "handles" (e.g., `FILE*`), where the internal structure is hidden. The
+ * canonical `infix` signature for any such handle is `*void`. This recipe
+ * also demonstrates using the Type Registry to create a readable alias for the
+ * handle type.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+int main() {
+    printf("--- Cookbook Chapter 1, Recipe 4: Working with Opaque Pointers ---\n");
+
+    // 1. Create a Type Registry to define a readable alias for our handle.
+    infix_registry_t * reg = infix_registry_create();
+    if (!reg) {
+        fprintf(stderr, "Failed to create registry.\n");
+        return 1;
+    }
+    // Define `@FileHandle` as a semantic alias for a generic pointer.
+    if (infix_register_types(reg, "@FileHandle = *void;") != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to register types.\n");
+        infix_registry_destroy(reg);
+        return 1;
+    }
+
+    // 2. Create trampolines for the file I/O functions using our alias.
+    infix_forward_t *t_fopen, *t_fputs, *t_fclose;
+    if (infix_forward_create(&t_fopen, "(*char, *char) -> @FileHandle", (void *)fopen, reg) != INFIX_SUCCESS ||
+        infix_forward_create(&t_fputs, "(*char, @FileHandle) -> int", (void *)fputs, reg) != INFIX_SUCCESS ||
+        infix_forward_create(&t_fclose, "(@FileHandle) -> int", (void *)fclose, reg) != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create one or more trampolines.\n");
+        infix_registry_destroy(reg);
+        return 1;
+    }
+
+    // 3. Call the functions in sequence to open, write to, and close a file.
+    void * file_handle = NULL;  // This will hold our opaque FILE*
+    const char * filename = "cookbook_test.txt";
+    const char * mode = "w";
+    void * fopen_args[] = {&filename, &mode};
+
+    printf("Attempting to open '%s' for writing...\n", filename);
+    infix_forward_get_code(t_fopen)(&file_handle, fopen_args);
+
+    if (file_handle) {
+        printf("File opened successfully. Handle: %p\n", file_handle);
+
+        const char * content = "Written by infix!";
+        void * fputs_args[] = {&content, &file_handle};
+        int fputs_result;
+        infix_forward_get_code(t_fputs)(&fputs_result, fputs_args);
+        printf("Wrote to file. fputs returned: %d\n", fputs_result);
+
+        int fclose_result;
+        // The argument to fclose is the value of file_handle.
+        // The FFI needs a pointer TO that value, wrapped in an array.
+        void * fclose_args[] = {&file_handle};
+        infix_forward_get_code(t_fclose)(&fclose_result, (void *[]){&file_handle});  // Use the new args array
+        printf("Closed file. fclose returned: %d\n", fclose_result);
+
+        // Clean up the created file.
+        remove(filename);
+    }
+    else
+        fprintf(stderr, "Failed to open file.\n");
+
+    // 4. Clean up all resources.
+    infix_forward_destroy(t_fopen);
+    infix_forward_destroy(t_fputs);
+    infix_forward_destroy(t_fclose);
+    infix_registry_destroy(reg);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec01_StructByValue.c
+++ b/eg/cookbook/Ch02_Rec01_StructByValue.c
@@ -1,0 +1,56 @@
+/**
+ * @file Ch02_Rec01_StructByValue.c
+ * @brief Cookbook Chapter 2, Recipe 1: Small Structs Passed by Value
+ *
+ * This example demonstrates calling a function that takes a small `struct`
+ * argument. For most ABIs, a small struct like this will be passed directly
+ * in CPU registers rather than on the stack. `infix` automatically handles
+ * this ABI-specific detail.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// A common C struct used in this chapter's examples
+typedef struct {
+    double x, y;
+} Point;
+
+// The native C function to be called.
+// It takes a Point struct by value and returns a modified copy.
+static Point move_point(Point p, double dx) {
+    p.x += dx;
+    return p;
+}
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 1: Small Structs Passed by Value ---\n");
+
+    // 1. Describe the signature: Point move_point(Point p, double dx);
+    //    The struct is described inline with its member types.
+    const char * signature = "({double, double}, double) -> {double, double}";
+
+    // 2. Create the trampoline.
+    infix_forward_t * trampoline = NULL;
+    infix_status status = infix_forward_create(&trampoline, signature, (void *)move_point, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(trampoline);
+
+    // 3. Prepare arguments and call.
+    Point start = {10.0, 20.0};
+    double delta_x = 5.5;
+    void * args[] = {&start, &delta_x};
+    Point end;
+
+    cif(&end, args);
+
+    printf("Calling move_point({10.0, 20.0}, 5.5)...\n");
+    printf("Result: { x=%.1f, y=%.1f } (Expected: {15.5, 20.0})\n", end.x, end.y);
+
+    // 4. Clean up.
+    infix_forward_destroy(trampoline);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec02_ReturnStruct.c
+++ b/eg/cookbook/Ch02_Rec02_ReturnStruct.c
@@ -1,0 +1,51 @@
+/**
+ * @file Ch02_Rec02_ReturnStruct.c
+ * @brief Cookbook Chapter 2, Recipe 2: Receiving a Struct from a Function
+ *
+ * This example demonstrates calling a function that returns a struct by value.
+ * `infix` handles the ABI-specific details of how the struct is returned,
+ * whether it's in one or more registers or via a hidden pointer passed by the
+ * caller.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// A common C struct used in this chapter's examples
+typedef struct {
+    double x, y;
+} Point;
+
+// The native C function to be called. It constructs and returns a Point.
+static Point make_point(double x, double y) { return (Point){x, y}; }
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 2: Receiving a Struct from a Function ---\n");
+
+    // 1. Describe the signature: Point make_point(double x, double y);
+    const char * signature = "(double, double) -> {double, double}";
+
+    // 2. Create the trampoline.
+    infix_forward_t * trampoline = NULL;
+    infix_status status = infix_forward_create(&trampoline, signature, (void *)make_point, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(trampoline);
+
+    // 3. Prepare arguments and a buffer for the returned struct.
+    double x = 100.0, y = 200.0;
+    void * args[] = {&x, &y};
+    Point result;
+
+    // 4. Call the function.
+    cif(&result, args);
+
+    printf("Calling make_point(100.0, 200.0)...\n");
+    printf("Received point: { x=%.1f, y=%.1f } (Expected: {100.0, 200.0})\n", result.x, result.y);
+
+    // 5. Clean up.
+    infix_forward_destroy(trampoline);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec03_LargeStruct.c
+++ b/eg/cookbook/Ch02_Rec03_LargeStruct.c
@@ -1,0 +1,56 @@
+/**
+ * @file Ch02_Rec03_LargeStruct.c
+ * @brief Cookbook Chapter 2, Recipe 3: Large Structs Passed by Reference
+ *
+ * This example demonstrates how `infix` handles structs that are too large to
+ * fit in registers. The C ABI specifies that such structs are passed by
+ * reference (i.e., a pointer to the struct is passed) or on the stack. From the
+ * `infix` user's perspective, the signature and call process are identical to
+ * a small struct; the library's ABI logic automatically handles the correct
+ * passing convention.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// A struct that is larger than 16 bytes, ensuring it will not be passed
+// entirely in registers on common 64-bit ABIs.
+typedef struct {
+    int data[8];
+} LargeStruct;
+
+// A native C function that takes the large struct by value.
+// The compiler will implement this as a pass-by-reference call under the hood.
+static int get_first_element(LargeStruct s) { return s.data[0]; }
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 3: Large Structs Passed by Reference ---\n");
+
+    // 1. Describe the signature for: int get_first_element(LargeStruct s);
+    //    The signature describes the struct by its contents.
+    const char * signature = "({[8:int]}) -> int";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)get_first_element, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Prepare the struct argument and call. Even though the ABI will pass a
+    //    pointer, the FFI call site still passes a pointer *to the struct value*.
+    LargeStruct my_struct = {{123, -1, -1, -1, -1, -1, -1, -1}};
+    void * args[] = {&my_struct};
+    int result;
+
+    cif(&result, args);
+
+    printf("Calling get_first_element() with a large struct...\n");
+    printf("Result: %d (Expected: 123)\n", result);
+
+    // 4. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec04_PackedStructs.c
+++ b/eg/cookbook/Ch02_Rec04_PackedStructs.c
@@ -1,0 +1,60 @@
+/**
+ * @file Ch02_Rec04_PackedStructs.c
+ * @brief Cookbook Chapter 2, Recipe 4: Working with Packed Structs
+ *
+ * This example demonstrates how to interface with C structs that have non-default
+ * alignment, typically specified with `#pragma pack(1)` or `__attribute__((packed))`.
+ * The `infix` signature language supports this with the `!{...}` syntax for 1-byte
+ * alignment, or `!N:{...}` for a specific N-byte alignment.
+ */
+#include <infix/infix.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// 1. Define a packed struct. Without packing, this struct would typically be
+//    16 bytes with 8-byte alignment due to the uint64_t member. With packing,
+//    it is 9 bytes with 1-byte alignment.
+#pragma pack(push, 1)
+typedef struct {
+    char a;
+    uint64_t b;
+} Packed;
+#pragma pack(pop)
+
+// The native C function to be called.
+static int process_packed(Packed p) {
+    // Check if the members were received correctly despite the unusual layout.
+    return (p.a == 'X' && p.b == 0x1122334455667788ULL) ? 42 : -1;
+}
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 4: Working with Packed Structs ---\n");
+
+    // 2. The signature uses `!{...}` to indicate a packed layout. `infix` will
+    //    calculate the correct unpadded size and 1-byte alignment.
+    const char * signature = "(!{char, uint64}) -> int";
+
+    // 3. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)process_packed, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 4. Prepare the packed struct instance and call.
+    Packed p = {'X', 0x1122334455667788ULL};
+    int result = 0;
+    void * args[] = {&p};
+
+    cif(&result, args);
+
+    printf("Calling a function with a 9-byte packed struct...\n");
+    printf("Result: %d (Expected: 42)\n", result);
+
+    // 5. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec05_Bitfields.c
+++ b/eg/cookbook/Ch02_Rec05_Bitfields.c
@@ -1,0 +1,63 @@
+/**
+ * @file Ch02_Rec05_Bitfields.c
+ * @brief Cookbook Chapter 2, Recipe 5: Working with Structs that Contain Bitfields
+ *
+ * This example demonstrates how to work with C structs that use bitfields. The
+ * `infix` signature language has no direct syntax for bitfields because their
+ * in-memory layout is implementation-defined and not portable.
+ *
+ * The solution is to model the struct based on its underlying integer storage
+ * type and manually pack/unpack the bitfield values in the host application
+ * before and after the FFI call.
+ */
+#include <infix/infix.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// The native C struct with bitfields. It occupies the space of a single uint32_t.
+typedef struct {
+    uint32_t a : 4;   // 4 bits
+    uint32_t b : 12;  // 12 bits
+    uint32_t c : 16;  // 16 bits
+} BitfieldStruct;
+
+// The native C function we want to call.
+static uint32_t process_bitfields(BitfieldStruct s) { return s.a + s.b + s.c; }
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 5: Working with Bitfields ---\n");
+
+    // 1. Describe the struct by its underlying integer storage. For the FFI
+    //    call, we treat it as a `struct { uint32_t; }`.
+    const char * signature = "({uint32}) -> uint32";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)process_bitfields, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Manually pack the data into a uint32_t using bitwise operators. This
+    //    mirrors what the C compiler does when assigning to bitfield members.
+    uint32_t packed_data = 0;
+    packed_data |= (15 & 0xF) << 0;         // Field a = 15
+    packed_data |= (1000 & 0xFFF) << 4;     // Field b = 1000
+    packed_data |= (30000 & 0xFFFF) << 16;  // Field c = 30000
+
+    // 4. The FFI call sees a simple struct containing a single uint32_t.
+    void * args[] = {&packed_data};
+    uint32_t result;
+
+    cif(&result, args);
+
+    printf("Calling function with manually packed bitfield data...\n");
+    printf("Bitfield sum: %u (Expected: 31015)\n", result);
+
+    // 5. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec06_Unions.c
+++ b/eg/cookbook/Ch02_Rec06_Unions.c
@@ -1,0 +1,54 @@
+/**
+ * @file Ch02_Rec06_Unions.c
+ * @brief Cookbook Chapter 2, Recipe 6: Working with Unions
+ *
+ * This example shows how to pass and return C `union` types. The `infix`
+ * signature for a union uses angle brackets `<...>` to list its members.
+ * The library calculates the correct size and alignment based on the largest
+ * and most-aligned member, respectively, just as a C compiler would.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// A simple union that can hold either an int or a float.
+typedef union {
+    int i;
+    float f;
+} Number;
+
+// Native C function that interprets the union as an integer.
+static int process_number_as_int(Number n) { return n.i * 2; }
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 6: Working with Unions ---\n");
+
+    // 1. Describe the signature for: int process_number_as_int(Number n);
+    //    The union's members are listed inside angle brackets.
+    const char * signature = "(<int, float>) -> int";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)process_number_as_int, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Prepare the union argument. We will set its integer member.
+    Number num_val;
+    num_val.i = 21;
+    int result = 0;
+    void * args[] = {&num_val};
+
+    // 4. Call the function.
+    cif(&result, args);
+
+    printf("Calling function, passing a union containing an integer...\n");
+    printf("Result: %d (Expected: 42)\n", result);
+
+    // 5. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec07_ArrayDecay.c
+++ b/eg/cookbook/Ch02_Rec07_ArrayDecay.c
@@ -1,0 +1,63 @@
+/**
+ * @file Ch02_Rec07_ArrayDecay.c
+ * @brief Cookbook Chapter 2, Recipe 7: Working with Fixed-Size Arrays
+ *
+ * This example clarifies a common point of confusion when working with arrays in C.
+ * When an array is passed as a function argument, it "decays" into a pointer to
+ * its first element. Therefore, the `infix` signature must describe it as a pointer,
+ * not an array type.
+ *
+ * The `[N:type]` array syntax is only used to describe an array when it is a
+ * member of a struct or a return type (a rare case).
+ */
+#include <infix/infix.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// A native C function that takes an array. In C, the `arr[4]` syntax in a
+// function parameter is purely cosmetic; the compiler treats it as `arr*`.
+// We add a `count` parameter to make the function safe.
+static int64_t sum_array_elements(const int64_t * arr, size_t count) {
+    int64_t sum = 0;
+    for (size_t i = 0; i < count; ++i)
+        sum += arr[i];
+    return sum;
+}
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 7: Working with Fixed-Size Arrays ---\n");
+
+    // 1. Describe the signature for: int64_t sum_array_elements(const int64_t* arr, size_t count);
+    //    Even though the original C declaration might look like `arr[4]`, it decays
+    //    to a pointer, so the signature must be `*sint64`. We use `size_t` for the count.
+    const char * signature = "(*sint64, size_t) -> sint64";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)sum_array_elements, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Prepare the array and other arguments.
+    int64_t my_array[] = {10, 20, 30, 40};
+    // The argument we pass is a pointer to the array (or its first element).
+    const int64_t * ptr_to_array = my_array;
+    size_t count = 4;
+    void * args[] = {&ptr_to_array, &count};
+    int64_t result = 0;
+
+    // 4. Call the function.
+    cif(&result, args);
+
+    printf("Calling function that takes a pointer to an array...\n");
+    printf("Sum of array is: %lld (Expected: 100)\n", (long long)result);
+
+    // 5. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec08_AdvancedRegistry.c
+++ b/eg/cookbook/Ch02_Rec08_AdvancedRegistry.c
@@ -1,0 +1,79 @@
+/**
+ * @file Ch02_Rec08_AdvancedRegistry.c
+ * @brief Cookbook Chapter 2, Recipe 8: Advanced Named Types (Recursive & Forward-Declared)
+ *
+ * This example demonstrates the full power of the `infix` Type Registry to model
+ * complex, real-world C data structures. It shows how to define:
+ * 1. A recursive type (a linked list `@Node`).
+ * 2. Mutually-recursive types (`@Employee` and `@Manager`) using forward declarations.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// C equivalent of the mutually-recursive types we will define:
+typedef struct Employee Employee;
+typedef struct Manager {
+    const char * name;
+    Employee * reports[10];  // A manager has direct reports
+} Manager;
+
+struct Employee {
+    const char * name;
+    Manager * manager;  // An employee has a manager
+};
+
+// A simple C function to demonstrate usage with these types.
+static const char * get_manager_name(Employee * e) { return e->manager ? e->manager->name : "None"; }
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 8: Advanced Named Types ---\n");
+
+    infix_registry_t * registry = infix_registry_create();
+    if (!registry) {
+        fprintf(stderr, "Failed to create registry.\n");
+        return 1;
+    }
+
+    // 1. Define the types in a string. Note the forward declarations (`@Name;`)
+    //    which are necessary because Manager refers to Employee, and vice-versa.
+    //    The parser handles out-of-order and recursive definitions automatically.
+    const char * definitions =
+        "@Employee; @Manager;"  // Forward declarations
+        "@Manager = { name:*char, reports:[10:*@Employee] };"
+        "@Employee = { name:*char, manager:*@Manager };";
+    if (infix_register_types(registry, definitions) != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to register types.\n");
+        infix_registry_destroy(registry);
+        return 1;
+    }
+    printf("Successfully registered mutually-recursive types.\n");
+
+    // 2. Create a trampoline using the named types.
+    infix_forward_t * trampoline = NULL;
+    infix_status status =
+        infix_forward_create(&trampoline, "(*@Employee) -> *char", (void *)get_manager_name, registry);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        infix_registry_destroy(registry);
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(trampoline);
+
+    // 3. Set up the C data structures and call the function.
+    Manager boss = {"Sanko", {NULL}};
+    Employee worker = {"Robinson", &boss};
+    Employee * p_worker = &worker;
+    const char * manager_name = NULL;
+    void * args[] = {&p_worker};
+
+    cif(&manager_name, args);
+
+    printf("Calling get_manager_name() via FFI...\n");
+    printf("The manager of %s is %s. (Expected: Sanko)\n", worker.name, manager_name);
+
+    // 4. Clean up.
+    infix_forward_destroy(trampoline);
+    infix_registry_destroy(registry);
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec09_ComplexNumbers.c
+++ b/eg/cookbook/Ch02_Rec09_ComplexNumbers.c
@@ -1,0 +1,64 @@
+/**
+ * @file Ch02_Rec09_ComplexNumbers.c
+ * @brief Cookbook Chapter 2, Recipe 9: Working with Complex Numbers
+ *
+ * This example demonstrates how to call C functions that use the standard
+ * C99 `_Complex` types. The `infix` signature for a complex number is `c[<base>]`,
+ * where `<base>` is the underlying floating-point type (`float` or `double`).
+ *
+ * NOTE: This feature is not supported by the MSVC compiler. This example will be
+ * skipped on Windows when using MSVC.
+ */
+
+// MSVC does not support <complex.h>, so we skip this entire example.
+#if !defined(_MSC_VER)
+
+#include <complex.h>
+#include <infix/infix.h>
+#include <stdio.h>
+
+// A native C function that operates on complex numbers.
+static double complex c_square(double complex z) { return z * z; }
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 9: Working with Complex Numbers ---\n");
+
+    // 1. The signature for `double _Complex` is `c[double]`.
+    const char * signature = "(c[double]) -> c[double]";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)c_square, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Prepare arguments and call. The C `complex.h` header provides the `I` macro.
+    double complex input = 3.0 + 4.0 * I;
+    double complex result;
+    void * args[] = {&input};
+
+    cif(&result, args);
+
+    printf("Calling a function that squares (3.0 + 4.0i)...\n");
+    printf("Result: (%.1f + %.1fi) (Expected: -7.0 + 24.0i)\n", creal(result), cimag(result));
+
+    // 4. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}
+
+#else  // On MSVC, provide a dummy main to satisfy the build system.
+
+#include <stdio.h>
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 9: Working with Complex Numbers ---\n");
+    printf("SKIPPED: MSVC does not support C99 _Complex types.\n");
+    return 0;
+}
+
+#endif

--- a/eg/cookbook/Ch02_Rec10_SIMD_AVX.c
+++ b/eg/cookbook/Ch02_Rec10_SIMD_AVX.c
@@ -1,0 +1,118 @@
+/**
+ * @file Ch02_Rec10_SIMD_AVX.c
+ * @brief Cookbook Chapter 2, Recipe 10: Working with SIMD Vectors (x86-64)
+ *
+ * This example demonstrates FFI calls with x86-64 SIMD vector types. It
+ * covers 256-bit AVX vectors (`__m256d`) and 512-bit AVX-512 vectors (`__m512d`).
+ * `infix` handles the ABI-specific rules for passing these types in YMM/ZMM registers.
+ *
+ * NOTE: This program must be compiled with the appropriate CPU features enabled
+ * (e.g., `-mavx2`, `-mavx512f` on GCC/Clang) and run on hardware that supports
+ * these instruction sets to avoid illegal instruction errors.
+ */
+#include <infix/infix.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#if defined(__AVX2__)
+#include <immintrin.h>
+#else
+typedef struct {
+    double d[4];
+} __m256d;
+typedef struct {
+    double d[8];
+} __m512d;
+#endif
+
+// Only define and use these helpers if intrinsics are available.
+#if defined(__AVX2__) || defined(__AVX512F__)
+#if defined(__GNUC__) || defined(__clang__)
+#include <cpuid.h>
+static bool cpu_has_avx2() {
+    unsigned int eax, ebx, ecx, edx;
+    return __get_cpuid(7, &eax, &ebx, &ecx, &edx) && (ebx & bit_AVX2);
+}
+static bool cpu_has_avx512f() {
+    unsigned int eax, ebx, ecx, edx;
+    return __get_cpuid(7, &eax, &ebx, &ecx, &edx) && (ebx & bit_AVX512F);
+}
+#elif defined(_MSC_VER)
+#include <intrin.h>
+static bool cpu_has_avx2() {
+    int info[4];
+    __cpuidex(info, 7, 0);
+    return (info[1] & (1 << 5));
+}
+static bool cpu_has_avx512f() {
+    int info[4];
+    __cpuidex(info, 7, 0);
+    return (info[1] & (1 << 16));
+}
+#else
+static bool cpu_has_avx2() { return false; }
+static bool cpu_has_avx512f() { return false; }
+#endif
+#endif
+
+#if defined(__AVX2__)
+__m256d vector_add_256(__m256d a, __m256d b) { return _mm256_add_pd(a, b); }
+#endif
+
+#if defined(__AVX512F__)
+__m512d vector_add_512(__m512d a, __m512d b) { return _mm512_add_pd(a, b); }
+#endif
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 10: Working with SIMD Vectors (x86-64) ---\n");
+
+#if defined(__AVX2__)
+    if (cpu_has_avx2()) {
+        printf("\n-- AVX (__m256d) Example --\n");
+        const char * sig256 = "(m256d, m256d) -> m256d";
+        infix_forward_t * t256 = NULL;
+        if (infix_forward_create(&t256, sig256, (void *)vector_add_256, NULL) == INFIX_SUCCESS) {
+            __m256d a = _mm256_set_pd(40.0, 30.0, 20.0, 10.0);
+            __m256d b = _mm256_set_pd(2.0, 12.0, 22.0, 32.0);
+            void * args[] = {&a, &b};
+            __m256d result;
+            infix_forward_get_code(t256)(&result, args);
+            double * d = (double *)&result;
+            printf("AVX vector result: [%.1f, %.1f, %.1f, %.1f]\n", d[0], d[1], d[2], d[3]);
+            printf("(Expected: [42.0, 42.0, 42.0, 42.0])\n");
+            infix_forward_destroy(t256);
+        }
+    }
+    else {
+        printf("\n-- AVX (__m256d) Example --\nSKIPPED: CPU does not support AVX2 at runtime.\n");
+    }
+#else
+    printf("\n-- AVX (__m256d) Example --\nSKIPPED: Not compiled with AVX2 support (e.g., -mavx2).\n");
+#endif
+
+#if defined(__AVX512F__)
+    if (cpu_has_avx512f()) {
+        printf("\n-- AVX-512 (__m512d) Example --\n");
+        const char * sig512 = "(m512d, m512d) -> m512d";
+        infix_forward_t * t512 = NULL;
+        if (infix_forward_create(&t512, sig512, (void *)vector_add_512, NULL) == INFIX_SUCCESS) {
+            __m512d a = _mm512_set_pd(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+            __m512d b = _mm512_set_pd(34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0, 41.0);
+            void * args[] = {&a, &b};
+            __m512d result;
+            infix_forward_get_code(t512)(&result, args);
+            double * d = (double *)&result;
+            printf("AVX-512 vector result: [%.1f, ..., %.1f]\n", d[0], d[7]);
+            printf("(Expected: [42.0, ..., 42.0])\n");
+            infix_forward_destroy(t512);
+        }
+    }
+    else {
+        printf("\n-- AVX-512 (__m512d) Example --\nSKIPPED: CPU does not support AVX-512F at runtime.\n");
+    }
+#else
+    printf("\n-- AVX-512 (__m512d) Example --\nSKIPPED: Not compiled with AVX-512 support (e.g., -mavx512f).\n");
+#endif
+
+    return 0;
+}

--- a/eg/cookbook/Ch02_Rec10_SIMD_NEON.c
+++ b/eg/cookbook/Ch02_Rec10_SIMD_NEON.c
@@ -1,0 +1,63 @@
+/**
+ * @file Ch02_Rec10_SIMD_NEON.c
+ * @brief Cookbook Chapter 2, Recipe 10: Working with SIMD Vectors (AArch64 NEON)
+ *
+ * This example demonstrates FFI calls with ARM NEON vector types, which are the
+ * standard SIMD instruction set on 64-bit ARM processors. It uses the `float32x4_t`
+ * type, a 128-bit vector containing four 32-bit floats.
+ *
+ * NOTE: This program must be compiled for the AArch64 architecture.
+ */
+
+#include <infix/infix.h>
+#include <stdio.h>
+
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
+
+// Native C function that performs a horizontal add on a NEON vector,
+// summing all four elements into a single scalar float.
+static float neon_horizontal_sum(float32x4_t vec) { return vaddvq_f32(vec); }
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 10: SIMD Vectors (AArch64 NEON) ---\n");
+
+    // 1. The signature `v[4:float]` directly maps to the `float32x4_t` type.
+    const char * signature = "(v[4:float]) -> float";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)neon_horizontal_sum, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Prepare the NEON vector argument.
+    float data[] = {10.0f, 20.0f, 5.5f, 6.5f};
+    float32x4_t input_vec = vld1q_f32(data);  // Load data from memory into a vector register.
+    void * args[] = {&input_vec};
+    float result;
+
+    // 4. Call the function.
+    cif(&result, args);
+
+    printf("Calling NEON horizontal sum with vector {10.0, 20.0, 5.5, 6.5}...\n");
+    printf("Result: %.1f (Expected: 42.0)\n", result);
+
+    // 5. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}
+
+#else  // If not compiled for ARM NEON
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 10: SIMD Vectors (AArch64 NEON) ---\n");
+    printf("SKIPPED: Not compiled for AArch64 with NEON support.\n");
+    return 0;
+}
+
+#endif

--- a/eg/cookbook/Ch02_Rec10_SIMD_SVE.c
+++ b/eg/cookbook/Ch02_Rec10_SIMD_SVE.c
@@ -1,0 +1,115 @@
+/**
+ * @file Ch02_Rec10_SIMD_SVE.c
+ * @brief Cookbook Chapter 2, Recipe 10: Working with SIMD Vectors (AArch64 SVE)
+ *
+ * This example demonstrates interfacing with ARM's Scalable Vector Extension (SVE).
+ * SVE is unique because the vector register size is not fixed by the architecture;
+ * it is implemented by the CPU and can vary (128 bits, 256 bits, 512 bits, etc.).
+ *
+ * This requires a dynamic approach:
+ * 1. Check for SVE support at runtime.
+ * 2. Query the CPU's implemented vector length.
+ * 3. Build the `infix` signature string *dynamically* based on the result.
+ * 4. Create and call the trampoline using the dynamically generated signature.
+ *
+ * NOTE: This program must be compiled for AArch64 with SVE enabled
+ * (e.g., `-march=armv8-a+sve`) and run on supporting hardware.
+ */
+#include <infix/infix.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Check if the compiler has SVE support enabled.
+#if defined(__ARM_FEATURE_SVE)
+#include <arm_sve.h>
+
+// Platform-specific headers for runtime CPU feature detection.
+#if defined(__linux__)
+#include <sys/auxv.h>
+#ifndef HWCAP_SVE
+#define HWCAP_SVE (1 << 22)  // From Linux kernel headers
+#endif
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
+// Helper function to check for SVE support at runtime.
+static bool is_sve_supported(void) {
+#if defined(__linux__)
+    return (getauxval(AT_HWCAP) & HWCAP_SVE) != 0;
+#elif defined(__APPLE__)
+    int sve_present = 0;
+    size_t size = sizeof(sve_present);
+    // Check the sysctl key for the SVE feature flag.
+    if (sysctlbyname("hw.optional.arm.FEAT_SVE", &sve_present, &size, NULL, 0) == 0)
+        return sve_present == 1;
+    return false;
+#else
+    // Other platforms (like Windows on ARM) would have their own detection methods.
+    return false;
+#endif
+}
+
+// Native C function using SVE for a horizontal add.
+// It sums all the double-precision elements in a scalable vector.
+static double sve_horizontal_add(svfloat64_t vec) { return svaddv_f64(svptrue_b64(), vec); }
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 10: SIMD Vectors (AArch64 SVE) ---\n");
+
+    if (!is_sve_supported()) {
+        printf("SKIPPED: SVE not supported on this CPU at runtime.\n");
+        return 0;
+    }
+
+    // 1. Query the vector length at runtime.
+    // `svcntd()` returns the number of `double` elements that fit in a Z-register.
+    size_t num_doubles = svcntd();
+    printf("Detected SVE vector length: %zu doubles (%zu bits)\n", num_doubles, num_doubles * 64);
+
+    // 2. Build the signature string dynamically based on the runtime result.
+    char signature[64];
+    snprintf(signature, sizeof(signature), "(v[%zu:double]) -> double", num_doubles);
+    printf("Generated dynamic signature: %s\n", signature);
+
+    // 3. Create the trampoline with the dynamic signature.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)sve_horizontal_add, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create SVE trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 4. Prepare arguments and call.
+    double * data = (double *)malloc(sizeof(double) * num_doubles);
+    for (size_t i = 0; i < num_doubles; ++i)
+        data[i] = (i == 0) ? 42.0 : 0.0;  // Place a value only in the first lane.
+
+    svbool_t pg = svptrue_b64();  // A "predicate governor" to operate on all lanes.
+    svfloat64_t input_vec = svld1_f64(pg, data);
+    void * args[] = {&input_vec};
+    double result;
+
+    cif(&result, args);
+
+    printf("Calling SVE horizontal sum...\n");
+    printf("Result: %.1f (Expected: 42.0)\n", result);
+
+    // 5. Clean up.
+    free(data);
+    infix_forward_destroy(t);
+
+    return 0;
+}
+
+#else  // If not compiled with SVE support
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 10: SIMD Vectors (AArch64 SVE) ---\n");
+    printf("SKIPPED: Not compiled with SVE support (e.g., -march=armv8-a+sve).\n");
+    return 0;
+}
+
+#endif

--- a/eg/cookbook/Ch02_Rec11_Enums.c
+++ b/eg/cookbook/Ch02_Rec11_Enums.c
@@ -1,0 +1,63 @@
+/**
+ * @file Ch02_Rec11_Enums.c
+ * @brief Cookbook Chapter 2, Recipe 11: Working with Enums
+ *
+ * This example shows how to handle C `enum` types. For the purpose of an FFI
+ * call, an enum behaves identically to its underlying integer type (which is
+ * `int` by default, unless specified otherwise).
+ *
+ * The `infix` signature `e:<type>` is used to represent an enum. This makes the
+ * signature more descriptive, but for ABI purposes, it is treated exactly like
+ * its underlying `<type>`.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// A native C enum and a function that uses it.
+typedef enum { STATUS_OK = 0, STATUS_WARN = 1, STATUS_ERR = -1 } StatusCode;
+
+static const char * status_to_string(StatusCode code) {
+    switch (code) {
+    case STATUS_OK:
+        return "OK";
+    case STATUS_WARN:
+        return "Warning";
+    case STATUS_ERR:
+        return "Error";
+    default:
+        return "Unknown";
+    }
+}
+
+int main() {
+    printf("--- Cookbook Chapter 2, Recipe 11: Working with Enums ---\n");
+
+    // 1. Describe the signature for: const char* status_to_string(StatusCode code);
+    //    The C `enum` is based on `int`, so we describe it as `e:int`.
+    const char * signature = "(e:int) -> *char";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)status_to_string, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Pass the enum value as its underlying integer type.
+    int code = STATUS_ERR;
+    const char * result_str = NULL;
+    void * args[] = {&code};
+
+    // 4. Call the function.
+    cif(&result_str, args);
+
+    printf("Calling status_to_string() with enum value STATUS_ERR...\n");
+    printf("Result: '%s' (Expected: 'Error')\n", result_str);
+
+    // 5. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}

--- a/eg/cookbook/Ch03_Rec01_QsortCallback.c
+++ b/eg/cookbook/Ch03_Rec01_QsortCallback.c
@@ -1,0 +1,58 @@
+/**
+ * @file Ch03_Rec01_QsortCallback.c
+ * @brief Cookbook Chapter 3, Recipe 1: Creating a Type-Safe Callback for `qsort`
+ *
+ * This example demonstrates a "reverse call" or callback. We generate a native
+ * C function pointer that can be passed to a C library function that expects one.
+ * Here, we use `infix_reverse_create_callback` to create a comparison function
+ * for the standard library's `qsort`.
+ *
+ * The key feature of this API is that the handler function (`compare_integers_handler`)
+ * has a clean, type-safe C signature that exactly matches what `qsort` expects.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// 1. The handler function has a standard C signature. No context pointer or
+//    generic argument arrays are needed for this high-level API.
+static int compare_integers_handler(const void * a, const void * b) {
+    // Standard comparison logic for qsort.
+    return (*(const int *)a - *(const int *)b);
+}
+
+int main() {
+    printf("--- Cookbook Chapter 3, Recipe 1: Creating a Type-Safe Callback ---\n");
+
+    // 2. Define the signature for the qsort comparison function:
+    //    int (*)(const void*, const void*)
+    const char * cmp_sig = "(*void, *void) -> int";
+
+    // 3. Create the reverse trampoline (callback).
+    infix_reverse_t * context = NULL;
+    infix_status status = infix_reverse_create_callback(&context, cmp_sig, (void *)compare_integers_handler, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create reverse trampoline.\n");
+        return 1;
+    }
+
+    // 4. Get the native, JIT-compiled function pointer from the context.
+    typedef int (*compare_func_t)(const void *, const void *);
+    compare_func_t my_comparator = (compare_func_t)infix_reverse_get_code(context);
+
+    // 5. Use the generated callback with the C library function.
+    int numbers[] = {5, 1, 4, 2, 3};
+    size_t num_count = sizeof(numbers) / sizeof(numbers[0]);
+
+    printf("Array before qsort: [ 5 1 4 2 3 ]\n");
+    qsort(numbers, num_count, sizeof(int), my_comparator);
+    printf("Array after qsort:  [ ");
+    for (size_t i = 0; i < num_count; ++i)
+        printf("%d ", numbers[i]);
+    printf("]\n");
+
+    // 6. Clean up.
+    infix_reverse_destroy(context);
+
+    return 0;
+}

--- a/eg/cookbook/Ch03_Rec02_StatefulCallback.c
+++ b/eg/cookbook/Ch03_Rec02_StatefulCallback.c
@@ -1,0 +1,72 @@
+/**
+ * @file Ch03_Rec02_StatefulCallback.c
+ * @brief Cookbook Chapter 3, Recipe 2: Creating a Stateful Callback
+ *
+ * This example demonstrates how to create a "closure" or stateful callback.
+ * This is essential when a C library's callback mechanism does not provide a
+ * `void* user_data` parameter, but your handler still needs access to
+ * application state.
+ *
+ * `infix_reverse_create_closure` is used for this. It takes a generic handler
+ * function and a `void*` pointer to your state, which can be retrieved inside
+ * the handler.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// Our application's state that the callback needs to access.
+typedef struct {
+    const char * name;
+    int sum;
+} AppContext;
+
+// 1. The handler for a closure has a generic signature. It receives arguments
+//    as a `void**` array.
+static void my_stateful_handler(infix_context_t * context, void * ret, void ** args) {
+    (void)ret;  // This handler's signature is `(int)->void`, so no return value.
+
+    // 2. Retrieve your application state from the context's user_data field.
+    AppContext * ctx = (AppContext *)infix_reverse_get_user_data(context);
+
+    // 3. Manually unbox the arguments from the void** array.
+    int item_value = *(int *)args[0];
+
+    printf("  -> Stateful handler received item: %d\n", item_value);
+    ctx->sum += item_value;
+}
+
+// A hypothetical C library function that takes a callback but no user_data.
+typedef void (*item_processor_t)(int);
+static void process_list(const int * items, int count, item_processor_t process_func) {
+    for (int i = 0; i < count; ++i)
+        process_func(items[i]);
+}
+
+int main() {
+    printf("--- Cookbook Chapter 3, Recipe 2: Creating a Stateful Callback ---\n");
+
+    // a. Prepare your state.
+    AppContext ctx = {"My List", 0};
+
+    // b. Create the closure, passing a pointer to your state as `user_data`.
+    infix_reverse_t * rt = NULL;
+    infix_status status = infix_reverse_create_closure(&rt, "(int) -> void", my_stateful_handler, &ctx, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create closure.\n");
+        return 1;
+    }
+
+    // c. Get the native function pointer and use it with the C library function.
+    item_processor_t processor_ptr = (item_processor_t)infix_reverse_get_code(rt);
+    int list[] = {10, 20, 30};
+
+    printf("Calling C library function with our stateful closure...\n");
+    process_list(list, 3, processor_ptr);
+    printf("...C library function finished.\n");
+    printf("Final sum for '%s': %d (Expected: 60)\n", ctx.name, ctx.sum);
+
+    // d. Clean up.
+    infix_reverse_destroy(rt);
+
+    return 0;
+}

--- a/eg/cookbook/Ch04_Rec01_VariadicPrintf.c
+++ b/eg/cookbook/Ch04_Rec01_VariadicPrintf.c
@@ -1,0 +1,50 @@
+/**
+ * @file Ch04_Rec01_VariadicPrintf.c
+ * @brief Cookbook Chapter 4, Recipe 1: Calling Variadic Functions like `printf`
+ *
+ * This example demonstrates how to call a C function that takes a variable
+ * number of arguments, such as `printf`.
+ *
+ * The key is the semicolon (`;`) in the signature string, which separates the
+ * fixed arguments from the variadic arguments. The signature must exactly
+ * match the types you are passing in a *specific call*. You would need a
+ * different trampoline for `printf("%s", ...)` versus `printf("%d", ...)`.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+int main() {
+    printf("--- Cookbook Chapter 4, Recipe 1: Calling Variadic Functions ---\n");
+
+    // 1. The signature for this specific call to `printf`.
+    //    Signature: int printf(const char* format, ...);
+    //    Our call:  printf("%d, %.2f", (int)42, (double)123.45);
+    //    The signature separates fixed and variadic args with a semicolon.
+    const char * signature = "(*char; int, double) -> int";
+
+    // 2. Create the trampoline bound to `printf`.
+    infix_forward_t * trampoline = NULL;
+    infix_status status = infix_forward_create(&trampoline, signature, (void *)printf, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create variadic trampoline.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(trampoline);
+
+    // 3. Prepare the arguments.
+    const char * fmt = "Formatted output from variadic call -> Count: %d, Value: %.2f\n";
+    int count = 42;
+    double value = 123.45;
+    void * args[] = {&fmt, &count, &value};
+    int result;  // To hold the return value of printf.
+
+    // 4. Make the call.
+    cif(&result, args);
+
+    printf("printf returned %d (number of characters written).\n", result);
+
+    // 5. Clean up.
+    infix_forward_destroy(trampoline);
+
+    return 0;
+}

--- a/eg/cookbook/Ch04_Rec02_CallbackAsArg.c
+++ b/eg/cookbook/Ch04_Rec02_CallbackAsArg.c
@@ -1,0 +1,71 @@
+/**
+ * @file Ch04_Rec02_CallbackAsArg.c
+ * @brief Cookbook Chapter 4, Recipe 2: Receiving and Calling a Function Pointer
+ *
+ * This example demonstrates a powerful composition of forward and reverse calls.
+ * We create a reverse trampoline (a callback) and then pass its function pointer
+ * as an argument to another C function using a forward trampoline.
+ *
+ * This pattern is very common in C APIs that use callbacks for event handling,
+ * sorting, or iteration.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// The "inner" handler function for our callback.
+static int multiply_handler(int x) {
+    printf("  -> Inner callback (multiply_handler) received: %d\n", x);
+    return x * 10;
+}
+
+// The "outer" C function that accepts a function pointer as an argument.
+static int harness_func(int (*worker_func)(int), int base_val) {
+    printf(" -> Harness function is about to call the worker_func...\n");
+    return worker_func(base_val);
+}
+
+int main() {
+    printf("--- Cookbook Chapter 4, Recipe 2: Passing a Callback as an Argument ---\n");
+
+    // 1. Create the "inner" reverse trampoline for our callback logic.
+    infix_reverse_t * inner_cb_ctx = NULL;
+    infix_status status = infix_reverse_create_callback(&inner_cb_ctx, "(int)->int", (void *)multiply_handler, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create inner callback.\n");
+        return 1;
+    }
+
+    // 2. Create the "outer" forward trampoline for the harness function.
+    //    The signature for a function pointer is `*(...)`.
+    //    Signature for: int harness_func( int(*)(int), int );
+    const char * harness_sig = "(*((int)->int), int) -> int";
+    infix_forward_t * harness_trampoline = NULL;
+    status = infix_forward_create(&harness_trampoline, harness_sig, (void *)harness_func, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create harness trampoline.\n");
+        infix_reverse_destroy(inner_cb_ctx);
+        return 1;
+    }
+
+    // 3. Get the native function pointer from our inner callback.
+    void * inner_cb_ptr = infix_reverse_get_code(inner_cb_ctx);
+    int value = 7;
+
+    // 4. Prepare arguments for the harness call. The first argument is the
+    //    function pointer we just generated.
+    void * harness_args[] = {&inner_cb_ptr, &value};
+    int result;
+
+    // 5. Make the call.
+    printf("Calling the harness function via FFI...\n");
+    infix_forward_get_code(harness_trampoline)(&result, harness_args);
+
+    printf("...Harness function returned.\n");
+    printf("Final result from nested callback: %d (Expected: 70)\n", result);
+
+    // 6. Clean up both trampolines.
+    infix_forward_destroy(harness_trampoline);
+    infix_reverse_destroy(inner_cb_ctx);
+
+    return 0;
+}

--- a/eg/cookbook/Ch04_Rec03_VTableCStyle.c
+++ b/eg/cookbook/Ch04_Rec03_VTableCStyle.c
@@ -1,0 +1,116 @@
+/**
+ * @file Ch04_Rec03_VTableCStyle.c
+ * @brief Cookbook Chapter 4, Recipe 3: Calling a Function Pointer from a Struct
+ *
+ * This example demonstrates how to call a function pointer that is a member of
+ * a struct. This pattern is common in C for emulating object-oriented v-tables
+ * or for creating plugin interfaces.
+ *
+ * The process is two-step:
+ * 1. Read the function pointer from the C struct.
+ * 2. Create an `infix` forward trampoline for that specific function pointer's
+ *    signature and call it.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// The "object" itself holds the data.
+typedef struct {
+    int val;
+} Adder;
+
+// Forward declare the v-table.
+typedef struct AdderVTable_t AdderVTable;
+
+// The "methods" are standalone C functions that take the object as a 'self' pointer.
+static int vtable_add(Adder * self, int amount) {
+    printf("  -> vtable_add called on Adder at %p with amount %d\n", (void *)self, amount);
+    return self->val + amount;
+}
+
+static void vtable_destroy(Adder * self) {
+    printf("  -> vtable_destroy called on Adder at %p\n", (void *)self);
+    free(self);
+}
+
+// The v-table struct holds the function pointers.
+struct AdderVTable_t {
+    int (*add)(Adder * self, int amount);
+    void (*destroy)(Adder * self);
+};
+
+// A global, constant instance of the v-table.
+const AdderVTable VTABLE = {vtable_add, vtable_destroy};
+
+// A "constructor" that allocates an Adder and returns it.
+static Adder * create_adder(int base) {
+    Adder * a = malloc(sizeof(Adder));
+    if (a)
+        a->val = base;
+    return a;
+}
+
+int main() {
+    printf("--- Cookbook Chapter 4, Recipe 3: C-Style V-Table Emulation ---\n");
+
+    // 1. Use the Type Registry to create clean, readable signatures for our types.
+    infix_registry_t * reg = infix_registry_create();
+    const char * defs =
+        // 1. Define the base struct type.
+        "@Adder = { val: int };"
+
+        // 2. Create an explicit, named alias for a POINTER to that struct.
+        "@AdderPtr = *@Adder;"
+
+        // 3. Now, use the simple pointer alias in the function pointer definitions.
+        "@Adder_add_fn = (@AdderPtr, int) -> int;"
+        "@Adder_destroy_fn = (@AdderPtr) -> void;"
+
+        // 4. The v-table definition remains the same, using the function pointer aliases.
+        "@AdderVTable = { add: @Adder_add_fn, destroy: @Adder_destroy_fn };";
+    if (infix_register_types(reg, defs) != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to register types.\n");
+        infix_error_details_t err = infix_get_last_error();
+        fprintf(stderr, "Infix Error [Code %d, Pos %zu]: %s\n", err.code, err.position, err.message);
+        infix_registry_destroy(reg);
+        return 1;
+    }
+
+    // 2. Create an instance of our C "object".
+    Adder * my_adder = create_adder(100);
+    const AdderVTable * vtable = &VTABLE;
+    printf("C 'object' created at %p with base value 100.\n", (void *)my_adder);
+
+    // 3. Read the function pointer directly from the v-table struct.
+    void * add_func_ptr = (void *)vtable->add;
+
+    // 4. Create a trampoline specifically for the `add` function's signature.
+    //    The target of this trampoline is the function pointer we just read.
+    infix_forward_t * t_add = NULL;
+    infix_status status = infix_forward_create(&t_add, "@Adder_add_fn", add_func_ptr, reg);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline for v-table method.\n");
+        free(my_adder);
+        infix_registry_destroy(reg);
+        return 1;
+    }
+
+    // 5. Call the method via the trampoline. The first argument must be the
+    //    'self' pointer to the object.
+    int amount_to_add = 23;
+    int result;
+    void * add_args[] = {&my_adder, &amount_to_add};
+
+    printf("Calling the 'add' method via FFI...\n");
+    infix_forward_get_code(t_add)(&result, add_args);
+
+    printf("Result from v-table call: %d (Expected: 123)\n", result);
+
+    // 6. Clean up.
+    vtable->destroy(my_adder);  // Call destroy directly for simplicity here.
+    infix_forward_destroy(t_add);
+    infix_registry_destroy(reg);
+
+    return 0;
+}

--- a/eg/cookbook/Ch04_Rec04_LongDouble.c
+++ b/eg/cookbook/Ch04_Rec04_LongDouble.c
@@ -1,0 +1,54 @@
+/**
+ * @file Ch04_Rec04_LongDouble.c
+ * @brief Cookbook Chapter 4, Recipe 4: Handling `long double`
+ *
+ * This example demonstrates how to call a function that uses the `long double` type.
+ * The size and ABI handling of `long double` are highly platform-specific:
+ * - On x86-64 Linux/BSD (System V ABI), it is often an 80-bit extended-precision
+ *   float passed on the x87 FPU stack.
+ * - On AArch64, it is a 128-bit quadruple-precision float.
+ * - On Windows (MSVC) and macOS, it is typically just an alias for `double` (64 bits).
+ *
+ * The `infix` keyword `longdouble` correctly resolves to the appropriate ABI
+ * handling on each platform, making the signature portable.
+ */
+#include <infix/infix.h>
+#include <math.h>
+#include <stdio.h>
+
+// A simple native function that uses long double.
+// `sqrtl` is the long double variant of `sqrt`.
+static long double native_sqrtl(long double x) { return sqrtl(x); }
+
+int main() {
+    printf("--- Cookbook Chapter 4, Recipe 4: Handling `long double` ---\n");
+    printf("Size of `long double` on this platform: %zu bytes\n", sizeof(long double));
+
+    // 1. Use the `longdouble` keyword. infix will determine the correct ABI rules.
+    const char * signature = "(longdouble) -> longdouble";
+
+    // 2. Create the trampoline.
+    infix_forward_t * t = NULL;
+    infix_status status = infix_forward_create(&t, signature, (void *)native_sqrtl, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline for long double.\n");
+        return 1;
+    }
+    infix_cif_func cif = infix_forward_get_code(t);
+
+    // 3. Prepare arguments and call. Use the 'L' suffix for a long double literal.
+    long double input = 144.0L;
+    long double result = 0.0L;
+    void * args[] = {&input};
+
+    cif(&result, args);
+
+    printf("Calling sqrtl(144.0L) via FFI...\n");
+    // Use %Lf to print a long double.
+    printf("Result: %Lf (Expected: 12.0)\n", result);
+
+    // 4. Clean up.
+    infix_forward_destroy(t);
+
+    return 0;
+}

--- a/eg/cookbook/Ch04_Rec05_Reentrancy.c
+++ b/eg/cookbook/Ch04_Rec05_Reentrancy.c
@@ -1,0 +1,99 @@
+/**
+ * @file Ch04_Rec05_Reentrancy.c
+ * @brief Cookbook Chapter 4, Recipe 5: Proving Reentrancy with Nested FFI Calls
+ *
+ * This test demonstrates that `infix` is fully reentrant, meaning it is safe to
+ * make an `infix` FFI call from within a handler that was invoked by another
+ * `infix` FFI call.
+ *
+ * The call chain is:
+ * 1. C `main` function (Forward Call) -> `harness` function
+ * 2. `harness` function (Native Call) -> `infix` Reverse Callback
+ * 3. Reverse Callback Handler (Forward Call) -> `multiply` function
+ *
+ * This works because `infix` uses no global mutable state; all context is either
+ * passed directly or stored in thread-local storage.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <string.h>  // For memcpy
+
+// The innermost C function that will be the final target.
+static int multiply(int a, int b) {
+    printf("    -> Innermost function `multiply(%d, %d)` called.\n", a, b);
+    return a * b;
+}
+
+// The generic handler for our reverse closure.
+// It needs state (the forward trampoline for `multiply`), so we MUST use a closure.
+static void nested_call_handler(infix_context_t * ctx, void * ret, void ** args) {
+    printf("   -> Nested callback handler entered.\n");
+    // 1. Retrieve the forward trampoline from user_data.
+    infix_forward_t * fwd_trampoline = (infix_forward_t *)infix_reverse_get_user_data(ctx);
+
+    // 2. Unbox the argument passed from the `harness` function.
+    int val = *(int *)args[0];
+    int multiplier = 5;
+    void * mult_args[] = {&val, &multiplier};
+
+    // 3. Make the nested forward call to `multiply`.
+    int result;
+    infix_forward_get_code(fwd_trampoline)(&result, mult_args);
+
+    // 4. Write the result to the return buffer for the `harness` function.
+    memcpy(ret, &result, sizeof(int));
+    printf("   -> Nested callback handler exiting.\n");
+}
+
+// The outer C function that takes our generated callback.
+static int harness(int (*func)(int), int input) {
+    printf(" -> Harness function entered, about to call the provided callback...\n");
+    int result = func(input);
+    printf(" -> Harness function exiting.\n");
+    return result;
+}
+
+int main() {
+    printf("--- Cookbook Chapter 4, Recipe 5: Proving Reentrancy ---\n");
+
+    // 1. Create the innermost forward trampoline (for `multiply`).
+    infix_forward_t * fwd_multiply = NULL;
+    if (infix_forward_create(&fwd_multiply, "(int, int)->int", (void *)multiply, NULL) != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create multiply trampoline.\n");
+        return 1;
+    }
+    // 2. Create the reverse closure, passing the `multiply` trampoline as its state.
+    infix_reverse_t * rev_nested = NULL;
+    if (infix_reverse_create_closure(&rev_nested, "(int)->int", nested_call_handler, fwd_multiply, NULL) !=
+        INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create nested closure.\n");
+        infix_forward_destroy(fwd_multiply);
+        return 1;
+    }
+    // 3. Create the outermost forward trampoline (for `harness`).
+    infix_forward_t * fwd_harness = NULL;
+    const char * harness_sig = "(*((int)->int), int)->int";
+    if (infix_forward_create(&fwd_harness, harness_sig, (void *)harness, NULL) != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create harness trampoline.\n");
+        infix_reverse_destroy(rev_nested);
+        infix_forward_destroy(fwd_multiply);
+        return 1;
+    }
+    // 4. Execute the entire call chain.
+    void * callback_ptr = infix_reverse_get_code(rev_nested);
+    int base_val = 8;
+    void * harness_args[] = {&callback_ptr, &base_val};
+    int final_result;
+
+    printf("Executing top-level forward call to `harness`...\n");
+    infix_forward_get_code(fwd_harness)(&final_result, harness_args);
+    printf("...Top-level call finished.\n");
+    printf("Final result from nested/reentrant call: %d (Expected: 40)\n", final_result);
+
+    // 5. Clean up all three trampolines in reverse order of creation.
+    infix_forward_destroy(fwd_harness);
+    infix_reverse_destroy(rev_nested);
+    infix_forward_destroy(fwd_multiply);
+
+    return 0;
+}

--- a/eg/cookbook/Ch04_Rec06_ThreadSafety.c
+++ b/eg/cookbook/Ch04_Rec06_ThreadSafety.c
@@ -1,0 +1,93 @@
+/**
+ * @file Ch04_Rec06_ThreadSafety.c
+ * @brief Cookbook Chapter 4, Recipe 6: Proving Thread Safety
+ *
+ * This example demonstrates that `infix` trampoline handles are thread-safe. A
+ * trampoline handle (`infix_forward_t*` or `infix_reverse_t*`) is immutable
+ * after creation and can be safely shared between threads. All mutable state
+ * (like error details) is stored in thread-local storage, so calls from
+ * different threads will not interfere with each other.
+ *
+ * This recipe creates a trampoline on the main thread and passes its callable
+ * function pointer to a worker thread, which then executes the FFI call.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// Platform-specific includes for threading.
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+// A simple C function to be the FFI target.
+static int add(int a, int b) { return a + b; }
+
+// A struct to pass data to our worker thread.
+typedef struct {
+    infix_cif_func cif;  // The callable trampoline function pointer.
+    int result;
+} thread_data_t;
+
+// The function our worker thread will execute.
+#if defined(_WIN32)
+DWORD WINAPI worker_thread_func(LPVOID arg) {
+#else
+void * worker_thread_func(void * arg) {
+#endif
+    thread_data_t * data = (thread_data_t *)arg;
+
+    printf("  -> Worker thread started.\n");
+
+    int a = 20, b = 22;
+    void * args[] = {&a, &b};
+
+    // Call the trampoline function pointer that was created on the main thread.
+    printf("  -> Worker thread making FFI call...\n");
+    data->cif(&data->result, args);
+    printf("  -> Worker thread finished FFI call.\n");
+
+#if defined(_WIN32)
+    return 0;
+#else
+    return NULL;
+#endif
+}
+
+int main() {
+    printf("--- Cookbook Chapter 4, Recipe 6: Proving Thread Safety ---\n");
+
+    // 1. Main thread: Create the trampoline.
+    printf("-> Main thread creating trampoline...\n");
+    infix_forward_t * trampoline = NULL;
+    infix_status status = infix_forward_create(&trampoline, "(int, int)->int", (void *)add, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+
+    // 2. Prepare the data struct to pass to the new thread.
+    thread_data_t data = {infix_forward_get_code(trampoline), 0};
+
+    // 3. Main thread: Spawn a worker thread, passing it the callable pointer.
+    printf("-> Main thread spawning worker thread...\n");
+#if defined(_WIN32)
+    HANDLE thread_handle = CreateThread(NULL, 0, worker_thread_func, &data, 0, NULL);
+    WaitForSingleObject(thread_handle, INFINITE);
+    CloseHandle(thread_handle);
+#else
+    pthread_t thread_id;
+    pthread_create(&thread_id, NULL, worker_thread_func, &data);
+    pthread_join(thread_id, NULL);
+#endif
+    printf("-> Main thread joined with worker thread.\n");
+
+    // 4. Main thread: Check the result computed by the worker thread.
+    printf("Result from worker thread: %d (Expected: 42)\n", data.result);
+
+    // 5. Main thread: Clean up the trampoline.
+    infix_forward_destroy(trampoline);
+
+    return 0;
+}

--- a/eg/cookbook/Ch05_Rec01_CppMangledNames.c
+++ b/eg/cookbook/Ch05_Rec01_CppMangledNames.c
@@ -1,0 +1,126 @@
+/**
+ * @file Ch05_Rec01_CppMangledNames.c
+ * @brief Cookbook Chapter 5, Recipe 1: Calling C++ Mangled Names
+ *
+ * This example demonstrates the advanced and fragile technique of manually
+ * replicating the C++ `new` and `delete` operators from C.
+ *
+ * This is a two-step process:
+ * 1. `new`: First, allocate raw memory (`malloc`), then call the constructor
+ *    on that memory with its mangled name.
+ * 2. `delete`: First, call the destructor with its mangled name, then free
+ *    the raw memory (`free`).
+ *
+ * @warning This technique is shown for educational purposes. It is not robust
+ * because it depends on compiler-specific name mangling. The strongly
+ * recommended best practice is to use `extern "C"` factory functions
+ * (`create_object`/`destroy_object`) to hide this complexity.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// The name of the shared library to load.
+#if defined(_WIN32)
+const char * LIB_NAME = "myclass.dll";
+#else
+const char * LIB_NAME = "./libmyclass.so";
+#endif
+
+int main() {
+    printf("--- Cookbook Chapter 5, Recipe 1: Calling C++ Mangled Names ---\n\n");
+
+    // 1. Open the C++ shared library.
+    infix_library_t * lib = infix_library_open(LIB_NAME);
+    if (!lib) {
+        fprintf(stderr, "Failed to open library '%s'.\n", LIB_NAME);
+        return 1;
+    }
+
+    // 2. Get the extern "C" helper functions and the mangled names.
+    size_t (*get_sizeof_myclass)() = infix_library_get_symbol(lib, "get_sizeof_myclass");
+    const char * (*get_mangled_constructor)() = infix_library_get_symbol(lib, "get_mangled_constructor");
+    const char * (*get_mangled_getvalue)() = infix_library_get_symbol(lib, "get_mangled_getvalue");
+    const char * (*get_mangled_destructor)() = infix_library_get_symbol(lib, "get_mangled_destructor");
+
+    const char * mangled_ctor = get_mangled_constructor();
+    const char * mangled_getval = get_mangled_getvalue();
+    const char * mangled_dtor = get_mangled_destructor();
+
+    printf("Looked up mangled names:\n");
+    printf("  Constructor: %s\n", mangled_ctor);
+    printf("  getValue:    %s\n", mangled_getval);
+    printf("  Destructor:  %s\n\n", mangled_dtor);
+
+    // 3. Manually replicate `new MyClass(100);`
+    printf("Simulating `MyClass* obj = new MyClass(100);`\n");
+
+    //  3a. Allocate raw memory for the object.
+    size_t obj_size = get_sizeof_myclass();
+    void * obj_memory = malloc(obj_size);
+    printf("Step 1: Allocated %zu bytes for object at address %p\n", obj_size, obj_memory);
+
+    //  3b. Call the constructor on the allocated memory.
+    //      Signature: void MyClass(MyClass* this, int val) -> "(*void, int) -> void"
+    void * ctor_ptr = infix_library_get_symbol(lib, mangled_ctor);
+    if (!ctor_ptr) {
+        fprintf(stderr, "Failed to find mangled constructor symbol: %s\n", mangled_ctor);
+        infix_library_close(lib);
+        return 1;
+    }
+    infix_forward_t * t_ctor;
+    infix_forward_create(&t_ctor, "(*void, int)->void", ctor_ptr, NULL);
+
+    int initial_val = 100;
+    void * ctor_args[] = {&obj_memory, &initial_val};
+
+    printf("Step 2: Calling constructor...\n");
+    infix_forward_get_code(t_ctor)(NULL, ctor_args);  // No return value
+    printf("Object constructed.\n\n");
+
+    // 4. Call a member function on the constructed object.
+    //    Signature: int getValue(const MyClass* this) -> "(*void)->int"
+    void * getval_ptr = infix_library_get_symbol(lib, mangled_getval);
+    if (!getval_ptr) {
+        fprintf(stderr, "Failed to find mangled getValue symbol: %s\n", mangled_getval);
+        // clean up and exit...
+        free(obj_memory);
+        infix_library_close(lib);
+        return 1;
+    }
+    infix_forward_t * t_getval;
+    infix_forward_create(&t_getval, "(*void)->int", getval_ptr, NULL);
+
+    int result;
+    void * getval_args[] = {&obj_memory};
+
+    printf("Calling member function `getValue()` via FFI...\n");
+    infix_forward_get_code(t_getval)(&result, getval_args);
+    printf("Result from getValue(): %d (Expected: 100)\n\n", result);
+
+    // 5. Manually replicate `delete obj;`
+    printf("Simulating `delete obj;`\n");
+
+    //  5a. Call the destructor.
+    //      Signature: void ~MyClass(MyClass* this) -> "(*void)->void"
+    void * dtor_ptr = infix_library_get_symbol(lib, mangled_dtor);
+    infix_forward_t * t_dtor;
+    infix_forward_create(&t_dtor, "(*void)->void", dtor_ptr, NULL);
+
+    void * dtor_args[] = {&obj_memory};
+    printf("Step 1: Calling destructor...\n");
+    infix_forward_get_code(t_dtor)(NULL, dtor_args);
+
+    //  5b. Free the raw memory.
+    printf("Step 2: Freeing object memory at %p\n", obj_memory);
+    free(obj_memory);
+    printf("Object destroyed and memory freed.\n\n");
+
+    // 6. Clean up all resources.
+    infix_forward_destroy(t_ctor);
+    infix_forward_destroy(t_getval);
+    infix_forward_destroy(t_dtor);
+    infix_library_close(lib);
+
+    return 0;
+}

--- a/eg/cookbook/Ch05_Rec02_CppTemplates.c
+++ b/eg/cookbook/Ch05_Rec02_CppTemplates.c
@@ -1,0 +1,63 @@
+/**
+ * @file Ch05_Rec02_CppTemplates.c
+ * @brief Cookbook Chapter 5, Recipe 2: Interfacing with C++ Templates
+ *
+ * This example demonstrates calling a specific instantiation of a C++ template
+ * class. While you can't call the template itself, you can find the mangled
+ * name for a concrete instantiation (e.g., `Box<double>`) and call its methods.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Mangled name for `Box<double>::get_value()` on GCC/Clang (Itanium ABI)
+const char * MANGLED_GET_DBL = "_ZNK3BoxIdE9get_valueEv";
+
+#if defined(_WIN32)
+const char * LIB_NAME = "box.dll";
+#else
+const char * LIB_NAME = "./libbox.so";
+#endif
+
+int main() {
+    printf("--- Cookbook Chapter 5, Recipe 2: Interfacing with C++ Templates ---\n");
+
+    infix_library_t * lib = infix_library_open(LIB_NAME);
+    if (!lib) {
+        fprintf(stderr, "Failed to open library '%s'.\n", LIB_NAME);
+        return 1;
+    }
+
+    // In a real scenario, you would call the mangled constructor.
+    // For simplicity, we'll just allocate memory and place the value directly.
+    double val = 3.14;
+    void * my_box = malloc(sizeof(double));
+    memcpy(my_box, &val, sizeof(double));
+    printf("Manually created a C++ 'Box<double>' object containing %f.\n", val);
+
+    void * p_get_value = infix_library_get_symbol(lib, MANGLED_GET_DBL);
+    if (!p_get_value) {
+        fprintf(stderr,
+                "Failed to find mangled template function '%s'. (Note: mangled names differ between compilers).\n",
+                MANGLED_GET_DBL);
+        free(my_box);
+        infix_library_close(lib);
+        return 1;
+    }
+
+    // Signature: double get_value(const Box<double>* this) -> "(*void) -> double"
+    infix_forward_t * t_get = NULL;
+    infix_forward_create(&t_get, "(*void) -> double", p_get_value, NULL);
+
+    double result;
+    infix_forward_get_code(t_get)(&result, (void *[]){&my_box});
+
+    printf("Value from C++ template object's get_value() method: %f (Expected: 3.14)\n", result);
+
+    free(my_box);
+    infix_forward_destroy(t_get);
+    infix_library_close(lib);
+
+    return 0;
+}

--- a/eg/cookbook/Ch05_Rec03_SemanticStrings.c
+++ b/eg/cookbook/Ch05_Rec03_SemanticStrings.c
@@ -1,0 +1,88 @@
+/**
+ * @file Ch05_Rec03_SemanticStrings.c
+ * @brief Cookbook Chapter 5, Recipe 3: Handling Strings and Semantic Types
+ *
+ * This example demonstrates the recommended pattern for handling types like strings
+ * (`char*`, `wchar_t*`) in a way that is robust for introspection.
+ *
+ * The core idea is to use the `infix` Type Registry to create "semantic aliases"
+ * that describe the *intent* of a type, not just its structure. A language binding
+ * can then inspect the name of the type to determine how to correctly marshal data.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <string.h>
+
+// A conceptual function demonstrating how a language binding would introspect.
+void introspect_and_print(const char * signature, infix_registry_t * registry) {
+    infix_arena_t * arena = NULL;
+    infix_type * ret_type = NULL;
+    infix_function_argument * args = NULL;
+    size_t num_args = 0, num_fixed = 0;
+
+    // 1. Parse the function signature to get its components.
+    infix_status status = infix_signature_parse(signature, &arena, &ret_type, &args, &num_args, &num_fixed, registry);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Introspection failed: Could not parse signature.\n");
+        return;
+    }
+
+    printf("\nIntrospecting signature: '%s'\n", signature);
+    for (size_t i = 0; i < num_args; ++i) {
+        const infix_type * arg_type = args[i].type;
+        printf("  - Arg %zu: ", i);
+
+        // 2. Check if the argument's type is a named struct.
+        if (arg_type->category == INFIX_TYPE_STRUCT && arg_type->meta.aggregate_info.name != NULL) {
+            const char * type_name = arg_type->meta.aggregate_info.name;
+            printf("is a semantic type named '@%s'. ", type_name);
+
+            // 3. Check for our semantic string names.
+            if (strcmp(type_name, "UTF16String") == 0)
+                printf("Action: Marshal as UTF-16 string.\n");
+            else if (strcmp(type_name, "UTF8String") == 0)
+                printf("Action: Marshal as UTF-8 string.\n");
+            else
+                printf("Action: Handle as a regular struct.\n");
+        }
+        else {
+            // It's a regular, non-semantic type.
+            char buffer[64];
+            if (infix_type_print(buffer, sizeof(buffer), arg_type, INFIX_DIALECT_SIGNATURE) == INFIX_SUCCESS)
+                printf("is a standard type '%s'.\n", buffer);
+            else
+                printf("is a standard type (print failed).\n");
+        }
+    }
+
+    infix_arena_destroy(arena);
+}
+
+int main() {
+    printf("--- Cookbook Chapter 5, Recipe 3: Handling Semantic String Types ---\n");
+
+    // 1. Define semantic aliases in a registry.
+    infix_registry_t * registry = infix_registry_create();
+    const char * type_defs =
+        "@HWND = *void;"
+        "@UTF16String = { data: *uint16 };"  // Represents wchar_t* on Windows
+        "@UTF8String = { data: *char };";    // Represents const char*
+    if (infix_register_types(registry, type_defs) != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to register types.\n");
+        infix_registry_destroy(registry);
+        return 1;
+    }
+
+    // 2. Define function signatures using these aliases.
+    const char * sig1 = "(@HWND, @UTF8String) -> void";
+    const char * sig2 = "(@UTF16String, @UTF16String) -> int";
+
+    // 3. Run the conceptual introspection.
+    introspect_and_print(sig1, registry);
+    introspect_and_print(sig2, registry);
+
+    // 4. Clean up.
+    infix_registry_destroy(registry);
+
+    return 0;
+}

--- a/eg/cookbook/Ch05_Rec04_CppVirtualFunctions.c
+++ b/eg/cookbook/Ch05_Rec04_CppVirtualFunctions.c
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 
 #if defined(_WIN32)
-const char * LIB_NAME = "libshapes.dll";
+const char * LIB_NAME = "shapes.dll";
 #else
 const char * LIB_NAME = "./libshapes.so";
 #endif

--- a/eg/cookbook/Ch05_Rec04_CppVirtualFunctions.c
+++ b/eg/cookbook/Ch05_Rec04_CppVirtualFunctions.c
@@ -43,9 +43,9 @@ int main() {
 
     // 4. Read function pointers from their known indices in the v-table.
     //    This is ABI-dependent and can be fragile.
-    void * area_fn_ptr = vtable[0];      // double area() const
-    void * name_fn_ptr = vtable[1];      // const char* name() const
-    void * dtor_fn_ptr = vtable[2];      // virtual ~Shape()
+    void * area_fn_ptr = vtable[0];  // double area() const
+    void * name_fn_ptr = vtable[1];  // const char* name() const
+    void * dtor_fn_ptr = vtable[2];  // virtual ~Shape()
     printf("Found `area()` function pointer at vtable[0]: %p\n", area_fn_ptr);
     printf("Found `name()` function pointer at vtable[1]: %p\n", name_fn_ptr);
     printf("Found `~Shape()` function pointer at vtable[2]: %p\n", dtor_fn_ptr);
@@ -58,13 +58,13 @@ int main() {
 
     // 6. Prepare the arguments array for the member function calls.
     //    The only argument is the `this` pointer.
-    void* args[] = { &rect_obj };
+    void * args[] = {&rect_obj};
 
     // 7. Call the virtual functions.
     double rect_area;
     const char * rect_name;
     infix_forward_get_code(t_area)(&rect_area, args);
-    infix_forward_get_code(t_name)((void*)&rect_name, args);
+    infix_forward_get_code(t_name)((void *)&rect_name, args);
 
     printf("\n--- Results ---\n");
     printf("Object's virtual name() returned: '%s'\n", rect_name);

--- a/eg/cookbook/Ch05_Rec04_CppVirtualFunctions.c
+++ b/eg/cookbook/Ch05_Rec04_CppVirtualFunctions.c
@@ -1,0 +1,85 @@
+/**
+ * @file Ch05_Rec04_CppVirtualFunctions.c
+ * @brief Cookbook Chapter 5, Recipe 4: Calling C++ Virtual Functions
+ *
+ * This example demonstrates how to call a C++ `virtual` function from C
+ * without any wrappers. This is achieved by emulating the compiler's v-table
+ * dispatch mechanism:
+ * 1. Read the hidden v-table pointer (vptr) from the object's memory.
+ * 2. Read the function pointer from the v-table at its known index.
+ * 3. Use `infix` to call that function pointer, passing the object as the
+ *    first ('this') argument.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#if defined(_WIN32)
+const char * LIB_NAME = "libshapes.dll";
+#else
+const char * LIB_NAME = "./libshapes.so";
+#endif
+
+int main() {
+    printf("--- Cookbook Chapter 5, Recipe 4: Calling C++ Virtual Functions ---\n");
+
+    infix_library_t * lib = infix_library_open(LIB_NAME);
+    if (!lib) {
+        fprintf(stderr, "Failed to open library '%s'.\n", LIB_NAME);
+        return 1;
+    }
+
+    // 1. Get the extern "C" factory function (the correct way to construct).
+    void * (*create_rectangle)(double, double) = infix_library_get_symbol(lib, "create_rectangle");
+
+    // 2. Create a C++ object via the factory.
+    void * rect_obj = create_rectangle(10.0, 5.0);
+    printf("Created C++ Rectangle object at address %p.\n", rect_obj);
+
+    // 3. Manually read the v-table pointer from the object.
+    void ** vptr = (void **)rect_obj;
+    void ** vtable = *vptr;
+    printf("Read v-table pointer: %p\n", (void *)vtable);
+
+    // 4. Read function pointers from their known indices in the v-table.
+    //    This is ABI-dependent and can be fragile.
+    void * area_fn_ptr = vtable[0];      // double area() const
+    void * name_fn_ptr = vtable[1];      // const char* name() const
+    void * dtor_fn_ptr = vtable[2];      // virtual ~Shape()
+    printf("Found `area()` function pointer at vtable[0]: %p\n", area_fn_ptr);
+    printf("Found `name()` function pointer at vtable[1]: %p\n", name_fn_ptr);
+    printf("Found `~Shape()` function pointer at vtable[2]: %p\n", dtor_fn_ptr);
+
+    // 5. Create trampolines for the discovered function pointers.
+    infix_forward_t *t_area, *t_name, *t_dtor;
+    infix_forward_create(&t_area, "(*void)->double", area_fn_ptr, NULL);
+    infix_forward_create(&t_name, "(*void)->*char", name_fn_ptr, NULL);
+    infix_forward_create(&t_dtor, "(*void)->void", dtor_fn_ptr, NULL);
+
+    // 6. Prepare the arguments array for the member function calls.
+    //    The only argument is the `this` pointer.
+    void* args[] = { &rect_obj };
+
+    // 7. Call the virtual functions.
+    double rect_area;
+    const char * rect_name;
+    infix_forward_get_code(t_area)(&rect_area, args);
+    infix_forward_get_code(t_name)((void*)&rect_name, args);
+
+    printf("\n--- Results ---\n");
+    printf("Object's virtual name() returned: '%s'\n", rect_name);
+    printf("Object's virtual area() returned: %f\n", rect_area);
+
+    // 8. Call the virtual destructor directly instead of an extern "C" wrapper.
+    printf("\nCalling virtual destructor at %p...\n", dtor_fn_ptr);
+    infix_forward_get_code(t_dtor)(NULL, args);
+    printf("Object destroyed.\n");
+
+    // 9. Clean up.
+    infix_forward_destroy(t_area);
+    infix_forward_destroy(t_name);
+    infix_forward_destroy(t_dtor);
+    infix_library_close(lib);
+
+    return 0;
+}

--- a/eg/cookbook/Ch05_Rec05_CppCallbacks.cpp
+++ b/eg/cookbook/Ch05_Rec05_CppCallbacks.cpp
@@ -1,0 +1,134 @@
+/**
+ * @file Ch05_Rec05_CppCallbacks.cpp
+ * @brief Cookbook Chapter 5, Recipe 5: Bridging C++ Callbacks
+ *
+ * This example demonstrates a powerful two-way FFI interaction: providing a
+ * C-side stateful callback to a C++ method.
+ *
+ * 1. A C++ `EventManager` class is exposed via its mangled method names.
+ * 2. The C side creates a stateful `infix` closure.
+ * 3. The C side calls the C++ `set_handler` method, passing the closure's raw
+ *    function pointer and its state pointer (`user_data`).
+ * 4. The C side then calls the C++ `trigger` method, which causes the C++ object
+ *    to invoke the C callback, correctly passing back the state pointer.
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <infix/infix.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// On GCC/Clang, find these with: nm -C libeventmanager.so | grep EventManager
+#if defined(__GNUC__) || defined(__clang__)
+const char * MANGLED_CTOR = "_ZN12EventManagerC1Ev";
+const char * MANGLED_SET_HANDLER = "_ZN12EventManager11set_handlerEPFviPvES0_";
+const char * MANGLED_TRIGGER = "_ZN12EventManager7triggerEi";
+#elif defined(_MSC_VER)
+// NOTE: These names are illustrative and may need to be adjusted for your specific MSVC version.
+const char * MANGLED_CTOR = "??0EventManager@@QEAA@XZ";
+const char * MANGLED_SET_HANDLER = "?set_handler@EventManager@@QEAAXP6AXHPEAX@Z0@Z";
+const char * MANGLED_TRIGGER = "?trigger@EventManager@@QEAAXH@Z";
+#endif
+
+#if defined(_WIN32)
+const char * LIB_NAME = "eventmanager.dll";
+#else
+const char * LIB_NAME = "./libeventmanager.so";
+#endif
+
+typedef struct {
+    int call_count;
+} C_AppState;
+
+void my_closure_handler(infix_context_t * context, void * ret, void ** args) {
+    (void)ret;
+    C_AppState * state = (C_AppState *)infix_reverse_get_user_data(context);
+    state->call_count++;
+    int value_from_cpp = *(int *)args[0];
+    printf("  -> C handler called (invocation #%d)! Received value: %d\n", state->call_count, value_from_cpp);
+}
+
+int main() {
+    printf("--- Cookbook Chapter 5, Recipe 5: Bridging C++ Callbacks ---\n");
+
+    infix_library_t * lib = infix_library_open(LIB_NAME);
+    if (!lib) {
+        fprintf(stderr, "Failed to open library '%s'.\n", LIB_NAME);
+        return 1;
+    }
+
+    size_t (*get_size)() = (size_t (*)())infix_library_get_symbol(lib, "EventManager_get_size");
+    void * p_ctor = infix_library_get_symbol(lib, MANGLED_CTOR);
+    void * p_set_handler = infix_library_get_symbol(lib, MANGLED_SET_HANDLER);
+    void * p_trigger = infix_library_get_symbol(lib, MANGLED_TRIGGER);
+
+    if (!get_size || !p_ctor || !p_set_handler || !p_trigger) {
+        fprintf(stderr, "Failed to find one or more mangled C++ symbols.\n");
+        infix_library_close(lib);
+        return 1;
+    }
+
+    infix_registry_t * reg = infix_registry_create();
+    const char * defs = "@CallbackFn = *((int, *void)->void);";
+    if (infix_register_types(reg, defs) != INFIX_SUCCESS) /* ... */
+        return 1;
+
+
+    // 1. Create the C-side state and the infix closure to manage it.
+    C_AppState app_state = {0};
+    infix_reverse_t * closure = NULL;
+    infix_reverse_create_closure(&closure, "(int, *void)->void", my_closure_handler, &app_state, NULL);
+
+    // 2. Create an instance of the C++ EventManager object by calling its constructor.
+    printf("Allocating %zu bytes for C++ object.\n", get_size());
+    void * manager_obj = malloc(get_size());
+
+    infix_forward_t * t_ctor;
+    infix_forward_create(&t_ctor, "(*void)->void", p_ctor, NULL);
+
+    // The constructor's only argument is the `this` pointer. Its value is the
+    // address stored in `manager_obj`. The args array must contain a pointer
+    // to the `manager_obj` variable itself.
+    void * ctor_args[] = {&manager_obj};
+    infix_forward_get_code(t_ctor)(NULL, ctor_args);
+
+    // 3. Call the C++ `set_handler` method to register our closure's components.
+    infix_forward_t * t_set_handler;
+    const char * sig = "(*void, @CallbackFn, *void)->void";
+    infix_forward_create(&t_set_handler, sig, p_set_handler, reg);
+
+    void * closure_c_func = infix_reverse_get_code(closure);
+    void * set_handler_args[] = {&manager_obj, &closure_c_func, &closure};
+    infix_forward_get_code(t_set_handler)(NULL, set_handler_args);
+
+    // 4. Call the C++ `trigger` method to make it invoke our C callback.
+    infix_forward_t * t_trigger;
+    infix_forward_create(&t_trigger, "(*void, int)->void", p_trigger, NULL);
+
+    int value_to_send = 42;
+    void * trigger_args[] = {&manager_obj, &value_to_send};
+    infix_forward_get_code(t_trigger)(NULL, trigger_args);  // First call
+
+    value_to_send = 99;
+    infix_forward_get_code(t_trigger)(NULL, trigger_args);  // Second call
+
+    printf("\nFinal C-side call count: %d (Expected: 2)\n", app_state.call_count);
+
+    // In a real app, you would call the mangled destructor here.
+    free(manager_obj);
+    infix_forward_destroy(t_ctor);
+    infix_forward_destroy(t_set_handler);
+    infix_forward_destroy(t_trigger);
+    infix_reverse_destroy(closure);
+    infix_registry_destroy(reg);
+    infix_library_close(lib);
+
+    return 0;
+}

--- a/eg/cookbook/Ch06_Rec01_SystemLibraries.c
+++ b/eg/cookbook/Ch06_Rec01_SystemLibraries.c
@@ -1,0 +1,74 @@
+/**
+ * @file Ch06_Rec01_SystemLibraries.c
+ * @brief Cookbook Chapter 6, Recipe 1: Calling Native System Libraries
+ *
+ * This example demonstrates how to dynamically load a system library (like
+ * `user32.dll` on Windows) at runtime, look up a function by name, and call it
+ * using an `infix` trampoline. This technique avoids the need to link against
+ * the library's import library at compile time.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+// This entire example is platform-specific.
+#if defined(_WIN32)
+#include <windows.h>  // For UINT, etc.
+
+int main() {
+    printf("--- Cookbook Chapter 6, Recipe 1: Calling Native System Libraries ---\n");
+
+    // 1. Open the system library by name. The OS will find it in the system path.
+    infix_library_t * user32 = infix_library_open("user32.dll");
+    if (!user32) {
+        fprintf(stderr, "Failed to open user32.dll.\n");
+        return 1;
+    }
+    printf("Successfully opened user32.dll.\n");
+
+    // 2. Look up the address of the `MessageBoxA` function.
+    void * pMessageBoxA = infix_library_get_symbol(user32, "MessageBoxA");
+    if (!pMessageBoxA) {
+        fprintf(stderr, "Failed to find symbol 'MessageBoxA'.\n");
+        infix_library_close(user32);
+        return 1;
+    }
+    printf("Found 'MessageBoxA' at address %p.\n", pMessageBoxA);
+
+    // 3. Define the signature for:
+    //    int MessageBoxA(HWND hWnd, LPCSTR lpText, LPCSTR lpCaption, UINT uType);
+    //    Note: HWND is a pointer type, LPCSTR is *char, and UINT is uint32.
+    const char * sig = "(*void, *char, *char, uint32) -> int";
+    infix_forward_t * t = NULL;
+    infix_forward_create(&t, sig, pMessageBoxA, NULL);
+    if (!t) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        infix_library_close(user32);
+        return 1;
+    }
+
+    // 4. Prepare arguments and call the function.
+    void * hwnd = NULL;  // No parent window
+    const char * text = "Hello from a dynamically loaded function!";
+    const char * caption = "infix FFI Example";
+    uint32_t type = 0x00000040L;  // MB_OK | MB_ICONINFORMATION
+    void * args[] = {&hwnd, &text, &caption, &type};
+    int result;
+
+    printf("Calling MessageBoxA via FFI... (a dialog box should appear)\n");
+    infix_forward_get_code(t)(&result, args);
+    printf("MessageBoxA returned: %d\n", result);
+
+    // 5. Clean up.
+    infix_forward_destroy(t);
+    infix_library_close(user32);
+
+    return 0;
+}
+#else
+// Dummy implementation for non-Windows platforms to allow compilation.
+int main() {
+    printf("--- Cookbook Chapter 6, Recipe 1: Calling Native System Libraries ---\n");
+    printf("SKIPPED: This example is for Windows only.\n");
+    return 0;
+}
+#endif

--- a/eg/cookbook/Ch06_Rec02_GlobalVariables.c
+++ b/eg/cookbook/Ch06_Rec02_GlobalVariables.c
@@ -1,0 +1,81 @@
+/**
+ * @file Ch06_Rec02_GlobalVariables.c
+ * @brief Cookbook Chapter 6, Recipe 2: Reading and Writing Global Variables
+ *
+ * This example demonstrates how to use `infix_read_global` and `infix_write_global`
+ * to interact with global variables exported from a shared library. The `infix`
+ * signature language is used to describe the type of the variable, ensuring that
+ * the correct number of bytes are read or written, which prevents memory corruption.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <string.h>
+
+// A C struct that matches the layout of the one in the shared library.
+typedef struct {
+    const char * name;
+    int version;
+} Config;
+
+// The name of the shared library to load.
+#if defined(_WIN32)
+const char * LIB_NAME = "globals.dll";
+#else
+const char * LIB_NAME = "./libglobals.so";
+#endif
+
+int main() {
+    printf("--- Cookbook Chapter 6, Recipe 2: Reading and Writing Global Variables ---\n");
+
+    infix_library_t * lib = infix_library_open(LIB_NAME);
+    if (!lib) {
+        fprintf(stderr, "Failed to open library '%s'.\n", LIB_NAME);
+        return 1;
+    }
+
+    // Example 1: Simple Integer Variable
+    printf("\n-- Interacting with 'global_counter' (int) --\n");
+    int counter_val = 0;
+
+    // 1. Read the initial value of the integer global.
+    infix_read_global(lib, "global_counter", "int", &counter_val, NULL);
+    printf("Initial value of global_counter: %d (Expected: 42)\n", counter_val);
+
+    // 2. Write a new value to the global variable.
+    int new_val = 100;
+    printf("Writing new value (100) to global_counter...\n");
+    infix_write_global(lib, "global_counter", "int", &new_val, NULL);
+
+    // 3. Read the value again to confirm the change.
+    counter_val = 0;  // Reset local variable to be sure.
+    infix_read_global(lib, "global_counter", "int", &counter_val, NULL);
+    printf("New value of global_counter: %d (Expected: 100)\n", counter_val);
+
+    // Example 2: Aggregate (Struct) Variable
+    printf("\n-- Interacting with 'g_config' (struct) --\n");
+    infix_registry_t * reg = infix_registry_create();
+    infix_register_types(reg, "@Config = {*char, int};");
+
+    Config local_config;
+    memset(&local_config, 0, sizeof(Config));
+
+    // 1. Read the global struct into our local variable.
+    infix_read_global(lib, "g_config", "@Config", &local_config, reg);
+    printf("Initial config: name='%s', version=%d (Expected: 'default', 1)\n", local_config.name, local_config.version);
+
+    // 2. Modify and write the struct back to the library.
+    Config new_config = {"updated", 2};
+    printf("Writing new config ('updated', 2) to g_config...\n");
+    infix_write_global(lib, "g_config", "@Config", &new_config, reg);
+
+    // 3. Read it back to verify.
+    memset(&local_config, 0, sizeof(Config));
+    infix_read_global(lib, "g_config", "@Config", &local_config, reg);
+    printf("Updated config: name='%s', version=%d (Expected: 'updated', 2)\n", local_config.name, local_config.version);
+
+    // Clean up
+    infix_registry_destroy(reg);
+    infix_library_close(lib);
+
+    return 0;
+}

--- a/eg/cookbook/Ch06_Rec03_LibraryDependencies.c
+++ b/eg/cookbook/Ch06_Rec03_LibraryDependencies.c
@@ -1,0 +1,60 @@
+/**
+ * @file Ch06_Rec03_LibraryDependencies.c
+ * @brief Cookbook Chapter 6, Recipe 3: Handling Library Dependencies
+ *
+ * This example demonstrates that `infix` does not require any special handling
+ * when loading a shared library that itself depends on other shared libraries.
+ * The operating system's dynamic linker automatically handles loading and
+ * linking all necessary dependencies.
+ *
+ * This example loads `libA`, which internally calls a function from `libB`.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+#if defined(_WIN32)
+const char * LIB_A_NAME = "libA.dll";
+#else
+const char * LIB_A_NAME = "./libA.so";
+#endif
+
+int main() {
+    printf("--- Cookbook Chapter 6, Recipe 3: Handling Library Dependencies ---\n");
+
+    // 1. We only need to open the top-level library, `libA`.
+    //    The OS dynamic linker will automatically find and load `libB.so`/`.dll`
+    //    because `libA` was linked against it.
+    printf("Loading library '%s'...\n", LIB_A_NAME);
+    infix_library_t * lib = infix_library_open(LIB_A_NAME);
+    if (!lib) {
+        fprintf(stderr,
+                "Failed to open library '%s'. Make sure its dependency (libB) is in the same directory.\n",
+                LIB_A_NAME);
+        return 1;
+    }
+    printf("Library loaded successfully.\n");
+
+    // 2. Get the symbol from `libA`.
+    void * p_entry = infix_library_get_symbol(lib, "entry_point_a");
+    if (!p_entry) {
+        fprintf(stderr, "Failed to find 'entry_point_a'.\n");
+        infix_library_close(lib);
+        return 1;
+    }
+
+    // 3. Create a trampoline and call the function.
+    infix_forward_t * t = NULL;
+    infix_forward_create(&t, "()->int", p_entry, NULL);
+
+    int result;
+    infix_forward_get_code(t)(&result, NULL);
+
+    printf("Called 'entry_point_a()' from libA...\n");
+    printf("Result from chained libraries: %d (Expected: 300)\n", result);
+
+    // 4. Clean up.
+    infix_forward_destroy(t);
+    infix_library_close(lib);
+
+    return 0;
+}

--- a/eg/cookbook/Ch07_Rec01_DynamicMarshalling.c
+++ b/eg/cookbook/Ch07_Rec01_DynamicMarshalling.c
@@ -1,0 +1,93 @@
+/**
+ * @file Ch07_Rec01_DynamicMarshalling.c
+ * @brief Cookbook Chapter 7, Recipe 1: Dynamic Struct Marshalling
+ *
+ * This example demonstrates a powerful use of the introspection API: dynamically
+ * packing data from an arbitrary source into a C-compatible struct layout at
+ * runtime. This is a core task for any language binding or data serialization layer.
+ *
+ * The `infix_type_from_signature` function is used to parse a signature string
+ * into a detailed `infix_type` graph. This graph contains all the `size`,
+ * `alignment`, and member `offset` information needed to correctly write data
+ * into a C-compatible memory buffer.
+ */
+#include <infix/infix.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+// The target C struct we want to populate dynamically.
+typedef struct {
+    int32_t user_id;
+    double score;
+    const char * name;
+} UserProfile;
+
+/**
+ * @brief A generic marshalling function that packs data into a struct.
+ * @param dest A pointer to the destination C struct buffer.
+ * @param sig The `infix` signature of the destination struct.
+ * @param src An array of `void*` pointers, where each pointer points to the
+ *            source data for the corresponding member, in order.
+ */
+static void marshal_ordered_data(void * dest, const char * sig, void ** src) {
+    // 1. Parse the signature to get the struct's layout information.
+    infix_type * type = NULL;
+    infix_arena_t * arena = NULL;
+    if (infix_type_from_signature(&type, &arena, sig, NULL) != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to parse signature for marshalling.\n");
+        return;
+    }
+
+    if (infix_type_get_category(type) != INFIX_TYPE_STRUCT) {
+        fprintf(stderr, "Signature is not a struct.\n");
+        infix_arena_destroy(arena);
+        return;
+    }
+
+    printf("Marshalling data into struct of size %zu, alignment %zu.\n",
+           infix_type_get_size(type),
+           infix_type_get_alignment(type));
+
+    // 2. Iterate through the struct's members.
+    for (size_t i = 0; i < infix_type_get_member_count(type); ++i) {
+        const infix_struct_member * member = infix_type_get_member(type, i);
+
+        // 3. Use the `offset` and `size` from the introspected type to
+        //    copy the data into the correct location in the destination buffer.
+        printf("  - Writing member '%s' (size %zu) to offset %zu\n",
+               member->name,
+               infix_type_get_size(member->type),
+               member->offset);
+
+        memcpy((char *)dest + member->offset, src[i], infix_type_get_size(member->type));
+    }
+
+    infix_arena_destroy(arena);
+}
+
+int main() {
+    printf("--- Cookbook Chapter 7, Recipe 1: Dynamic Struct Marshalling ---\n");
+
+    // Our source data, coming from some dynamic source.
+    int32_t id = 123;
+    double score = 98.6;
+    const char * name = "Sanko";
+    void * my_data[] = {&id, &score, &name};
+
+    // The signature of the target struct. Note the named fields.
+    const char * profile_sig = "{id:int32, score:double, name:*char}";
+
+    // The destination C struct buffer, initially zeroed.
+    UserProfile profile_buffer = {0};
+
+    // Marshal the data.
+    marshal_ordered_data(&profile_buffer, profile_sig, my_data);
+
+    printf("\nResulting C struct contents:\n");
+    printf("  user_id: %d (Expected: 123)\n", profile_buffer.user_id);
+    printf("  score:   %.1f (Expected: 98.6)\n", profile_buffer.score);
+    printf("  name:    \"%s\" (Expected: \"Sanko\")\n", profile_buffer.name);
+
+    return 0;
+}

--- a/eg/cookbook/Ch07_Rec02_DynamicSignatures.c
+++ b/eg/cookbook/Ch07_Rec02_DynamicSignatures.c
@@ -1,0 +1,61 @@
+/**
+ * @file Ch07_Rec02_DynamicSignatures.c
+ * @brief Cookbook Chapter 7, Recipe 2: Building a Signature String at Runtime
+ *
+ * This example shows that since `infix` signatures are just strings, they can be
+ * constructed dynamically at runtime. This is a powerful feature for dynamic
+ * languages or systems where the structure of data is not known until runtime
+ * (e.g., it's defined in a configuration file or a user script).
+ *
+ * The dynamically generated signature can then be parsed to get layout
+ * information, which is perfect for data marshalling or dynamic RPC systems.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+    printf("--- Cookbook Chapter 7, Recipe 2: Building a Signature String at Runtime ---\n");
+
+    // Imagine this data comes from a config file or a user script.
+    const char * user_defined_fields[] = {"int", "int", "double"};
+    int num_fields = 3;
+
+    char signature_buffer[256] = "{";
+    size_t current_len = 1;
+
+    // 1. Build the signature string dynamically using standard string functions.
+    printf("Dynamically building signature from field list...\n");
+    for (int i = 0; i < num_fields; ++i) {
+        // Append the type name.
+        strncat(signature_buffer, user_defined_fields[i], sizeof(signature_buffer) - current_len - 1);
+        current_len += strlen(user_defined_fields[i]);
+
+        // Append a comma if it's not the last member.
+        if (i < num_fields - 1) {
+            strncat(signature_buffer, ",", sizeof(signature_buffer) - current_len - 1);
+            current_len++;
+        }
+    }
+    strncat(signature_buffer, "}", sizeof(signature_buffer) - current_len - 1);
+
+    printf("Dynamically generated signature: %s\n", signature_buffer);
+
+    // 2. Use the dynamic signature to get layout information.
+    infix_type * dynamic_type = NULL;
+    infix_arena_t * arena = NULL;
+    infix_status status = infix_type_from_signature(&dynamic_type, &arena, signature_buffer, NULL);
+
+    if (status == INFIX_SUCCESS && dynamic_type) {
+        printf("Successfully parsed dynamic signature.\n");
+        printf("  - Calculated size: %zu bytes\n", infix_type_get_size(dynamic_type));
+        printf("  - Calculated alignment: %zu bytes\n", infix_type_get_alignment(dynamic_type));
+    }
+    else {
+        fprintf(stderr, "Failed to parse the dynamically generated signature.\n");
+    }
+
+    infix_arena_destroy(arena);
+
+    return 0;
+}

--- a/eg/cookbook/Ch07_Rec03_IntrospectWrapper.c
+++ b/eg/cookbook/Ch07_Rec03_IntrospectWrapper.c
@@ -1,0 +1,88 @@
+/**
+ * @file Ch07_Rec03_IntrospectWrapper.c
+ * @brief Cookbook Chapter 7, Recipe 3: Introspecting a Trampoline for a Wrapper
+ *
+ * This example demonstrates how a language binding or a generic wrapper function
+ * can use the trampoline introspection API to validate arguments at runtime before
+ * making an FFI call. This allows for more robust error checking.
+ */
+#include <infix/infix.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+// A simple C function to be our FFI target.
+static int add_and_multiply(int a, double b) { return (int)((double)a * b); }
+
+/**
+ * @brief A conceptual generic "wrapper" function for an unbound trampoline.
+ *
+ * In a real language binding, this function would take language-native objects
+ * as arguments, unbox them into a C `void**` array, and perform type checking.
+ *
+ * @param trampoline An unbound trampoline for the desired signature.
+ * @param target_func The native C function to call.
+ * @param args An array of pointers to the C argument values.
+ * @param num_provided_args The number of arguments provided by the caller.
+ * @param ret_buffer A buffer to receive the return value.
+ * @return `true` on success, `false` on failure.
+ */
+static bool dynamic_wrapper(
+    infix_forward_t * trampoline, void * target_func, void ** args, size_t num_provided_args, void * ret_buffer) {
+    printf("--- Inside dynamic_wrapper ---\n");
+
+    // 1. Introspect the trampoline to get expected argument count.
+    size_t num_expected_args = infix_forward_get_num_args(trampoline);
+    printf("Introspection: Trampoline expects %zu arguments.\n", num_expected_args);
+
+    if (num_provided_args != num_expected_args) {
+        fprintf(stderr,
+                "ERROR: Incorrect number of arguments. Expected %zu, but got %zu.\n",
+                num_expected_args,
+                num_provided_args);
+        return false;
+    }
+
+    // A real binding would also loop through and check the types of each argument
+    // using `infix_forward_get_arg_type(trampoline, i)`.
+
+    printf("Argument count matches. Making FFI call...\n");
+
+    // 2. Make the call using the unbound function pointer.
+    infix_unbound_cif_func cif = infix_forward_get_unbound_code(trampoline);
+    cif(target_func, ret_buffer, args);
+
+    printf("--- Exiting dynamic_wrapper ---\n");
+    return true;
+}
+
+int main() {
+    printf("--- Cookbook Chapter 7, Recipe 3: Introspecting a Trampoline ---\n");
+
+    const char * signature = "(int, double) -> int";
+    infix_forward_t * trampoline = NULL;
+    infix_status status = infix_forward_create_unbound(&trampoline, signature, NULL);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline.\n");
+        return 1;
+    }
+
+    // Test Case 1: Correct number of arguments
+    printf("\n--- Calling wrapper with correct number of arguments ---\n");
+    int a1 = 10;
+    double b1 = 4.2;
+    void * correct_args[] = {&a1, &b1};
+    int result1 = 0;
+    dynamic_wrapper(trampoline, (void *)add_and_multiply, correct_args, 2, &result1);
+    printf("Wrapper call finished. Result: %d (Expected: 42)\n", result1);
+
+    // Test Case 2: Incorrect number of arguments
+    printf("\n--- Calling wrapper with incorrect number of arguments ---\n");
+    int a2 = 10;
+    void * incorrect_args[] = {&a2};
+    int result2 = 0;
+    dynamic_wrapper(trampoline, (void *)add_and_multiply, incorrect_args, 1, &result2);
+
+    infix_forward_destroy(trampoline);
+
+    return 0;
+}

--- a/eg/cookbook/Ch08_Rec01_CustomAllocators.c
+++ b/eg/cookbook/Ch08_Rec01_CustomAllocators.c
@@ -1,0 +1,58 @@
+/**
+ * @file Ch08_Rec01_CustomAllocators.c
+ * @brief Cookbook Chapter 8, Recipe 1: Using Custom Memory Allocators
+ *
+ * This example demonstrates how to integrate `infix` with a custom memory
+ * manager. This is useful for applications that need to track allocations,
+ * use a memory pool, or integrate with a garbage collector.
+ *
+ * The mechanism is simple: define the `infix_malloc`, `infix_free`, etc.,
+ * macros *before* including `infix.h`. All internal memory operations in the
+ * library will then be redirected to your custom functions.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// 1. Define your custom memory management functions.
+//    These simple wrappers just print a message and track the total allocated memory.
+static size_t g_total_allocated = 0;
+static void * tracking_malloc(size_t size) {
+    g_total_allocated += size;
+    printf(">> Custom Malloc: Allocating %zu bytes (Total outstanding: %zu)\n", size, g_total_allocated);
+    return malloc(size);
+}
+
+static void tracking_free(void * ptr) {
+    // A real tracking allocator would need to know the size of the block being freed.
+    // For this example, we just log the call.
+    printf(">> Custom Free: Deallocating block at %p\n", ptr);
+    free(ptr);
+}
+
+// 2. Define the infix override macros BEFORE including infix.h
+#define infix_malloc(size) tracking_malloc(size)
+#define infix_free(ptr) tracking_free(ptr)
+// You can also override infix_calloc and infix_realloc if needed.
+
+#include <infix/infix.h>
+
+void dummy_func() {}
+
+int main() {
+    printf("--- Cookbook Chapter 8, Recipe 1: Using Custom Memory Allocators ---\n");
+
+    printf("\nCreating trampoline with custom allocators...\n");
+    infix_forward_t * trampoline = NULL;
+
+    // All internal allocations for the trampoline will now use `tracking_malloc`.
+    infix_forward_create(&trampoline, "()->void", (void *)dummy_func, NULL);
+
+    printf("\nDestroying trampoline...\n");
+    // All free operations will now use `tracking_free`.
+    infix_forward_destroy(trampoline);
+
+    printf("\nDone.\n");
+
+    return 0;
+}

--- a/eg/cookbook/Ch08_Rec02_ManualAPI.c
+++ b/eg/cookbook/Ch08_Rec02_ManualAPI.c
@@ -1,0 +1,76 @@
+/**
+ * @file Ch08_Rec02_ManualAPI.c
+ * @brief Cookbook Chapter 8, Recipe 2: The Full Manual API Lifecycle
+ *
+ * This example demonstrates how to create a trampoline without using the signature
+ * parser. This is the "Manual API" and is ideal for performance-critical
+ * applications or language bindings that construct type information programmatically.
+ *
+ * The process involves:
+ * 1. Creating a memory arena.
+ * 2. Building `infix_type` objects for all required types (structs, primitives)
+ *    by allocating them from the arena.
+ * 3. Calling `infix_forward_create_manual` with the constructed types.
+ * 4. Destroying the arena and trampoline when done.
+ */
+#include <infix/infix.h>
+#include <stddef.h>  // For offsetof
+#include <stdio.h>
+
+// The C types and function we want to call
+typedef struct {
+    double x, y;
+} Point;
+Point move_point(Point p, double dx) {
+    p.x += dx;
+    return p;
+}
+
+int main() {
+    printf("--- Cookbook Chapter 8, Recipe 2: The Full Manual API Lifecycle ---\n");
+
+    // 1. Create an arena to hold all our type definitions.
+    infix_arena_t * arena = infix_arena_create(4096);
+    if (!arena) {
+        fprintf(stderr, "Failed to create arena.\n");
+        return 1;
+    }
+
+    // 2. Manually define the 'Point' struct type.
+    //    We use the C `offsetof` macro to get the correct member offsets.
+    infix_struct_member point_members[] = {
+        infix_type_create_member("x", infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE), offsetof(Point, x)),
+        infix_type_create_member("y", infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE), offsetof(Point, y))};
+    infix_type * point_type = NULL;
+    infix_type_create_struct(arena, &point_type, point_members, 2);
+    printf("Manually created 'Point' type description.\n");
+
+    // 3. Define the argument types for the function `Point move_point(Point, double)`.
+    infix_type * arg_types[] = {point_type, infix_type_create_primitive(INFIX_PRIMITIVE_DOUBLE)};
+    printf("Prepared argument type array.\n");
+
+    // 4. Create the trampoline using the manually constructed types.
+    infix_forward_t * trampoline = NULL;
+    infix_status status = infix_forward_create_manual(&trampoline, point_type, arg_types, 2, 2, (void *)move_point);
+    if (status != INFIX_SUCCESS) {
+        fprintf(stderr, "Failed to create trampoline via manual API.\n");
+        infix_arena_destroy(arena);
+        return 1;
+    }
+    printf("Trampoline created successfully via manual API.\n");
+
+    // 5. Call the function as usual.
+    Point start = {10.0, 20.0};
+    double delta_x = 5.5;
+    void * args[] = {&start, &delta_x};
+    Point end;
+
+    infix_forward_get_code(trampoline)(&end, args);
+    printf("Manual API call result: Moved point has x = %.1f (Expected: 15.5)\n", end.x);
+
+    // 6. Clean up.
+    infix_forward_destroy(trampoline);
+    infix_arena_destroy(arena);  // Frees the 'point_type' as well.
+
+    return 0;
+}

--- a/eg/cookbook/Ch08_Rec03_ArenaCallFrame.c
+++ b/eg/cookbook/Ch08_Rec03_ArenaCallFrame.c
@@ -1,0 +1,91 @@
+/**
+ * @file Ch08_Rec03_ArenaCallFrame.c
+ * @brief Cookbook Chapter 8, Recipe 3: Building a Dynamic Call Frame with an Arena
+ *
+ * This example demonstrates an advanced, high-performance technique for language
+ * bindings: using an `infix` arena to build the entire call frame for an FFI call.
+ *
+ * In a binding, you receive arguments from the host language (e.g., Python),
+ * unbox them into temporary C values, and create the `void* args[]` array of
+ * pointers to these temporaries. Using `malloc` for this in a tight loop is
+ * inefficient.
+ *
+ * This recipe shows how to allocate both the unboxed C values AND the `void**`
+ * array from a single, short-lived arena. This is extremely fast and simplifies
+ * cleanup to a single `infix_arena_destroy` call, preventing memory leaks.
+ */
+#include <infix/infix.h>
+#include <stdarg.h>  // For va_list
+#include <stdio.h>
+#include <string.h>  // For memcpy
+
+// A sample C function we want to call dynamically.
+static void process_user_data(int id, double score, const char * name) {
+    printf("  -> C Function Received: ID=%d, Score=%.2f, Name='%s'\n", id, score, name);
+}
+
+/**
+ * This function simulates the core logic of a language binding's generic "call" function.
+ * It takes a va_list to represent dynamic arguments coming from a script.
+ */
+static void dynamic_ffi_call(infix_forward_t * trampoline, void * target_func, int arg_count, ...) {
+    // 1. Create a temporary arena for this call's entire data frame.
+    infix_arena_t * call_arena = infix_arena_create(1024);
+    if (!call_arena) {
+        fprintf(stderr, "Error: Could not create call arena.\n");
+        return;
+    }
+
+    // 2. Allocate the void** array itself from the arena.
+    void ** args = infix_arena_alloc(call_arena, sizeof(void *) * arg_count, _Alignof(void *));
+
+    va_list va;
+    va_start(va, arg_count);
+
+    // 3. For each argument, allocate space for its C value in the arena,
+    //    copy the value, and store the pointer in the `args` array.
+    for (int i = 0; i < arg_count; ++i) {
+        // In a real binding, you would inspect the trampoline's arg types here.
+        // For this example, we'll assume the order (int, double, const char*).
+        if (i == 0) {  // int
+            int * val_ptr = infix_arena_alloc(call_arena, sizeof(int), _Alignof(int));
+            *val_ptr = va_arg(va, int);
+            args[i] = val_ptr;
+        }
+        else if (i == 1) {  // double
+            double * val_ptr = infix_arena_alloc(call_arena, sizeof(double), _Alignof(double));
+            *val_ptr = va_arg(va, double);
+            args[i] = val_ptr;
+        }
+        else if (i == 2) {  // const char*
+            const char ** val_ptr = infix_arena_alloc(call_arena, sizeof(const char *), _Alignof(const char *));
+            *val_ptr = va_arg(va, const char *);
+            args[i] = val_ptr;
+        }
+    }
+    va_end(va);
+
+    // 4. Make the FFI call using the arena-managed data.
+    printf("Making dynamic FFI call with arena-allocated frame...\n");
+    infix_unbound_cif_func cif = infix_forward_get_unbound_code(trampoline);
+    cif(target_func, NULL, args);
+
+    // 5. A single free cleans up the void** array AND all the argument values.
+    infix_arena_destroy(call_arena);
+    printf("Call frame arena destroyed.\n");
+}
+
+int main() {
+    printf("--- Cookbook Chapter 8, Recipe 3: Building a Dynamic Call Frame with an Arena ---\n");
+
+    // Setup the trampoline once and cache it (as a real binding would).
+    const char * signature = "(int, double, *char) -> void";
+    infix_forward_t * trampoline = NULL;
+    infix_forward_create_unbound(&trampoline, signature, NULL);
+
+    dynamic_ffi_call(trampoline, (void *)process_user_data, 3, 123, 99.8, "test user");
+
+    infix_forward_destroy(trampoline);
+
+    return 0;
+}

--- a/eg/cookbook/Ch09_Rec01_ErrorReporting.c
+++ b/eg/cookbook/Ch09_Rec01_ErrorReporting.c
@@ -1,0 +1,65 @@
+/**
+ * @file Ch09_Rec01_ErrorReporting.c
+ * @brief Cookbook Chapter 9, Recipe 1: Advanced Error Reporting for the Parser
+ *
+ * This example demonstrates how to get detailed, thread-safe error information
+ * when an `infix` API call fails. This is especially useful for providing rich
+ * feedback to users when they provide an invalid signature string.
+ *
+ * After a parsing function fails, a call to `infix_get_last_error()` returns an
+ * `infix_error_details_t` struct containing the error code, a human-readable
+ * message, and the exact character position of the error in the source string.
+ */
+#include <infix/infix.h>
+#include <stdio.h>
+
+/**
+ * @brief A helper function that attempts to parse a signature and reports
+ *        detailed error information on failure.
+ * @param signature The signature string to parse.
+ */
+static void report_parse_error(const char * signature) {
+    infix_type * type = NULL;
+    infix_arena_t * arena = NULL;
+
+    printf("\n--- Attempting to parse signature: ---\n\"%s\"\n", signature);
+
+    infix_status status = infix_type_from_signature(&type, &arena, signature, NULL);
+
+    if (status != INFIX_SUCCESS) {
+        // 1. Get the detailed error information for the current thread.
+        infix_error_details_t err = infix_get_last_error();
+
+        fprintf(stderr, "FAILURE: Parsing failed.\n");
+
+        // 2. Print a helpful diagnostic, including a caret pointing to the error.
+        fprintf(stderr, "  %s\n", signature);
+        fprintf(stderr, "  %*s^\n", (int)err.position, "");  // Print spaces to align the caret
+        fprintf(stderr, "Error Details:\n");
+        fprintf(stderr, "  - Category: %d\n", err.category);
+        fprintf(stderr, "  - Code: %d\n", err.code);
+        fprintf(stderr, "  - Position: %zu\n", err.position);
+        fprintf(stderr, "  - Message: %s\n", err.message);
+    }
+    else {
+        printf("SUCCESS: Signature parsed correctly.\n");
+    }
+
+    // Clean up resources if parsing was successful.
+    infix_arena_destroy(arena);
+}
+
+int main() {
+    printf("--- Cookbook Chapter 9, Recipe 1: Advanced Error Reporting ---\n");
+
+    // Test Case 1: An invalid character '^' instead of a comma.
+    report_parse_error("{int, double, ^*char}");
+
+    // Test Case 2: An unterminated struct.
+    report_parse_error("{int, double");
+
+    // Test Case 3: A valid signature to show the success path.
+    report_parse_error("{int, double, *char}");
+
+    return 0;
+}

--- a/eg/cookbook/libs/Box.cpp
+++ b/eg/cookbook/libs/Box.cpp
@@ -1,0 +1,109 @@
+/**
+ * @file Box.cpp
+ * @brief C++ template class for the template interop example.
+ *
+ * This file demonstrates the complex and fragile technique of manually forcing
+ * the compiler to generate and export specific template methods from a shared
+ * library. This is necessary because the compiler will not generate code for
+ * template methods unless they are explicitly used within the library itself
+ * or explicitly instantiated.
+ *
+ * The technique shown here is to create dummy `extern "C"` functions whose only
+ * purpose is to call the template methods we need. This creates a dependency
+ * chain that forces the linker to keep the code for those methods.
+ */
+#include <iostream>
+#include <string>
+
+// Cross-platform macro for exporting symbols from a shared library.
+// On Windows, this is __declspec(dllexport).
+// On Linux/macOS with GCC/Clang, this is __attribute__((visibility("default"))).
+// This is necessary when compiling with the `-fvisibility=hidden` flag.
+#if defined(_WIN32)
+#define MYCLASS_API __declspec(dllexport)
+#else
+#define MYCLASS_API __attribute__((visibility("default")))
+#endif
+
+// The class template itself must be marked for export. This tells the compiler
+// that instantiations of this template may need to be visible externally.
+template <typename T>
+class MYCLASS_API Box {
+private:
+    T m_value;
+
+public:
+    Box(T initial_value) : m_value(initial_value) {
+        std::cout << "  -> C++ Box<T>::Box() called. Storing value." << std::endl;
+    }
+    T get_value() const {
+        std::cout << "  -> C++ Box<T>::get_value() called. Returning value." << std::endl;
+        return m_value;
+    }
+    void set_value(T new_value) {
+        m_value = new_value;
+        std::cout << "  -> C++ Box<T>::set_value() called. New value stored." << std::endl;
+    }
+    ~Box() { std::cout << "  -> C++ Box<T>::~Box() called." << std::endl; }
+};
+
+
+// --- Extern "C" Helpers for C Interop ---
+// These are the "clean" factory functions and helpers that the C code will use.
+extern "C" {
+// We use a void* handle to hide the C++ template type from the C code.
+MYCLASS_API void * create_box_double(double val) { return new Box<double>(val); }
+MYCLASS_API void * create_box_int(int val) { return new Box<int>(val); }
+MYCLASS_API void destroy_box_double(void * box) { delete static_cast<Box<double> *>(box); }
+MYCLASS_API void destroy_box_int(void * box) { delete static_cast<Box<int> *>(box); }
+
+MYCLASS_API size_t get_sizeof_box_double() { return sizeof(Box<double>); }
+MYCLASS_API size_t get_sizeof_box_int() { return sizeof(Box<int>); }
+
+// Helpers to return the compiler-specific mangled names for the C code to look up.
+MYCLASS_API const char * get_mangled_box_double_getvalue() {
+#if defined(_MSC_VER)
+    return "?get_value@?$Box@N@@QEBANXZ";  // MSVC mangling for Box<double>::get_value()
+#else
+    return "_ZNK3BoxIdE9get_valueEv";  // Itanium (GCC/Clang) mangling for Box<double>::get_value()
+#endif
+}
+
+MYCLASS_API const char * get_mangled_box_int_getvalue() {
+#if defined(_MSC_VER)
+    return "?get_value@?$Box@H@@QEBAHXZ";  // MSVC mangling for Box<int>::get_value()
+#else
+    return "_ZNK3BoxIiE9get_valueEv";  // Itanium (GCC/Clang) mangling for Box<int>::get_value()
+#endif
+}
+// Add more mangled name helpers for set_value, etc., as needed by the example.
+}
+
+// --- THE "HARD WAY": MANUALLY FORCING METHOD INSTANTIATION AND EXPORT ---
+//
+// To demonstrate the complexity, we create these dummy `extern "C"` functions.
+// Their only purpose is to call the template methods we need from C.
+// Because these dummy functions are exported (using MYCLASS_API), the compiler
+// is forced to generate the code for the template methods they depend on.
+// These functions are NOT meant to be called from the C example; they are a build-time trick.
+extern "C" {
+/**
+ * @brief Dummy function to force the export of all methods for `Box<double>`.
+ */
+MYCLASS_API void _internal_force_export_all_methods_double() {
+    Box<double> * temp = new Box<double>(0.0);  // Instantiates constructor
+    temp->set_value(1.0);                       // Instantiates set_value
+    temp->get_value();                          // Instantiates get_value
+    delete temp;                                // Instantiates destructor
+}
+
+/**
+ * @brief Dummy function to force the export of all methods for `Box<int>`.
+ */
+MYCLASS_API void _internal_force_export_all_methods_int() {
+    Box<int> * temp = new Box<int>(0);  // Instantiates constructor
+    temp->set_value(1);                 // Instantiates set_value
+    temp->get_value();                  // Instantiates get_value
+    delete temp;                        // Instantiates destructor
+}
+}

--- a/eg/cookbook/libs/EventManager.cpp
+++ b/eg/cookbook/libs/EventManager.cpp
@@ -1,0 +1,79 @@
+/**
+ * @file EventManager.cpp
+ * @brief A C++ class that accepts a C-style callback, for the C-to-C++ callback example.
+ *
+ * This version includes all necessary components for robust, cross-platform FFI:
+ * 1. A cross-platform API_EXPORT macro to ensure the class is visible.
+ * 2. An extern "C" helper to provide the true size of the class to C code.
+ * 3. A dummy extern "C" function to prevent the linker from discarding the
+ *    class's methods as "dead code".
+ */
+#include <iostream>
+
+// A robust, cross-platform macro for exporting symbols from a shared library.
+#if defined(_WIN32)
+#define API_EXPORT __declspec(dllexport)
+#else
+#define API_EXPORT __attribute__((visibility("default")))
+#endif
+
+// The entire class is marked for export, making all its public methods visible.
+class API_EXPORT EventManager {
+private:
+    // We store the C-style callback as two separate parts:
+    // the function pointer and the opaque user_data pointer.
+    void (*handler_ptr)(int, void *);
+    void * user_data;
+
+public:
+    EventManager();
+
+    // A method to register a C-style callback.
+    void set_handler(void (*h)(int, void *), void * data);
+
+    // A method to trigger the stored callback.
+    void trigger(int value);
+};
+
+// The constructor must also be public and exported.
+EventManager::EventManager() : handler_ptr(nullptr), user_data(nullptr) {
+    // std::cout << "  -> C++ EventManager constructed.\n";
+}
+
+void EventManager::set_handler(void (*h)(int, void *), void * data) {
+    // std::cout << "  -> C++ EventManager received and stored the C callback.\n";
+    this->handler_ptr = h;
+    this->user_data = data;
+}
+
+void EventManager::trigger(int value) {
+    if (handler_ptr) {
+        // std::cout << "  -> C++ is triggering the C callback with value " << value << "...\n";
+        //  When the callback is invoked, we pass back the opaque user_data pointer
+        //  that was originally provided to set_handler.
+        handler_ptr(value, user_data);
+    }
+    else
+        std::cout << "  -> C++ trigger called, but no handler is registered.\n";
+}
+
+// --- Extern "C" Helpers for a Stable C ABI ---
+extern "C" {
+/**
+ * @brief Provides the true, compiler-determined size of the EventManager class.
+ * This is the ONLY safe way for C code to know how much memory to allocate.
+ */
+API_EXPORT size_t EventManager_get_size() { return sizeof(EventManager); }
+
+/**
+ * @brief A dummy function to force the linker to keep all class methods.
+ * Its only purpose is to call every method, creating a dependency that
+ * prevents the linker from discarding them as "dead code."
+ */
+API_EXPORT void _internal_force_export_all_eventmanager_methods() {
+    EventManager * temp = new EventManager();
+    temp->set_handler(nullptr, nullptr);
+    temp->trigger(0);
+    delete temp;
+}
+}

--- a/eg/cookbook/libs/MyClass.cpp
+++ b/eg/cookbook/libs/MyClass.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file MyClass.cpp
+ * @brief A simple C++ class and the extern "C" helpers needed for the mangled name FFI example.
+ */
+#include <iostream>
+#include <string>
+
+// On Windows, we must explicitly export symbols we want to use in other modules.
+#if defined(_WIN32)
+#define EXPORT_API __declspec(dllexport)
+#else
+#define EXPORT_API __attribute__((visibility("default")))
+#endif
+
+class EXPORT_API MyClass {
+private:
+    int m_val;
+
+public:
+    EXPORT_API MyClass(int val) : m_val(val) {}
+    EXPORT_API int getValue() const { return m_val; }
+    EXPORT_API ~MyClass() {}
+};
+
+// This is the stable C Application Binary Interface (ABI) that our C code will use.
+extern "C" {
+/**
+ * @brief A dummy factory function.
+ * Its only purpose is to be exported and to call `new MyClass()`.
+ * This creates a dependency that forces the C++ linker to include the
+ * code for the constructor in the final shared library.
+ * This function is NOT intended to be called by the C example.
+ */
+EXPORT_API MyClass * _internal_force_linker_to_keep_constructor(int val) { return new MyClass(val); }
+/** @brief Returns the size of the C++ class, so C code can malloc() it. */
+EXPORT_API size_t get_sizeof_myclass() { return sizeof(MyClass); }
+
+/**
+ * @brief Returns the compiler-specific mangled name for the constructor.
+ */
+EXPORT_API const char * get_mangled_constructor() {
+
+
+#if defined(_MSC_VER)
+    // MSVC Mangled Name for: public: __cdecl MyClass::MyClass(int)
+    return "??0MyClass@@QEAA@H@Z";
+#else
+    // Itanium C++ ABI (GCC/Clang) Mangled Name for: MyClass::MyClass(int)
+    return "_ZN7MyClassC1Ei";
+#endif
+}
+
+/** @brief Returns the compiler-specific mangled name for the getValue method. */
+EXPORT_API const char * get_mangled_getvalue() {
+#if defined(_MSC_VER)
+    // MSVC Mangled Name for: public: int __cdecl MyClass::getValue(void)const
+    return "?getValue@MyClass@@QEBAHXZ";
+#else
+    // Itanium C++ ABI (GCC/Clang) Mangled Name for: int MyClass::getValue() const
+    return "_ZNK7MyClass8getValueEv";
+#endif
+}
+
+/** @brief Returns the compiler-specific mangled name for the destructor. */
+EXPORT_API const char * get_mangled_destructor() {
+#if defined(_MSC_VER)
+    // MSVC Mangled Name for: public: __cdecl MyClass::~MyClass(void)
+    return "??1MyClass@@QEAA@XZ";
+#else
+    // Itanium C++ ABI (GCC/Clang) Mangled Name for: MyClass::~MyClass()
+    return "_ZN7MyClassD1Ev";
+#endif
+}
+// This function's only purpose is to call every C++ method we want to export,
+// creating a dependency that forces the linker to keep their code.
+EXPORT_API void _internal_force_linker_to_keep_all_symbols() {
+    // Create a temporary object. This forces the constructor to be kept.
+    MyClass * temp = new MyClass(0);
+
+    // Call getValue(). This forces getValue() to be kept.
+    temp->getValue();
+
+    // Delete the object. This forces the destructor to be kept.
+    delete temp;
+}
+}

--- a/eg/cookbook/libs/clib.c
+++ b/eg/cookbook/libs/clib.c
@@ -1,0 +1,15 @@
+/**
+ * @file clib.cdddddddddddddddd
+ * @brief Implementation of a simple C library for the C++ callback example.
+ */
+#include "clib.h"
+#include <stdio.h>
+
+void process_data(int * data, int count, void (*callback)(int item, void * user_data), void * user_data) {
+    printf("  -> C Library: Starting to process %d items.\n", count);
+    for (int i = 0; i < count; ++i) {
+        printf("  -> C Library: Invoking callback for item %d.\n", data[i]);
+        callback(data[i], user_data);
+    }
+    printf("  -> C Library: Finished processing.\n");
+}

--- a/eg/cookbook/libs/clib.h
+++ b/eg/cookbook/libs/clib.h
@@ -1,0 +1,16 @@
+/**
+ * @file clib.h
+ * @brief Header for a simple C library used in the C++ callback example.
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// A C function that takes a callback and user data.
+void process_data(int * data, int count, void (*callback)(int item, void * user_data), void * user_data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/eg/cookbook/libs/libA.c
+++ b/eg/cookbook/libs/libA.c
@@ -1,0 +1,14 @@
+/**
+ * @file libA.c
+ * @brief A shared library that depends on another shared library (libB).
+ */
+
+// Declare the function imported from libB.
+// The linker will resolve this at load time.
+int helper_from_lib_b();
+
+// The main entry point for this library that we will call from our example.
+int entry_point_a() {
+    // This function calls a function from its dependency.
+    return 200 + helper_from_lib_b();
+}

--- a/eg/cookbook/libs/libB.c
+++ b/eg/cookbook/libs/libB.c
@@ -1,0 +1,7 @@
+/**
+ * @file libB.c
+ * @brief A dependency library for the library dependency chain example.
+ */
+
+// This function is exported from libB and will be called by libA.
+int helper_from_lib_b() { return 100; }

--- a/eg/cookbook/libs/libglobals.c
+++ b/eg/cookbook/libs/libglobals.c
@@ -1,0 +1,21 @@
+/**
+ * @file libglobals.c
+ * @brief A simple shared library that exports global variables for FFI testing.
+ */
+
+#if defined(_WIN32)
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT __attribute__((visibility("default")))
+#endif
+
+// A simple exported integer variable.
+EXPORT int global_counter = 42;
+
+// An exported struct variable.
+typedef struct {
+    const char * name;
+    int version;
+} Config;
+
+EXPORT Config g_config = {"default", 1};

--- a/eg/cookbook/libs/shapes.cpp
+++ b/eg/cookbook/libs/shapes.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file shapes.cpp
+ * @brief A simple polymorphic C++ class hierarchy for the virtual function FFI example.
+ */
+#include <cmath>
+
+// On Windows, M_PI is not always defined in <cmath>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+class Shape {
+public:
+    virtual double area() const = 0;        // 1st virtual function (index 0)
+    virtual const char * name() const = 0;  // 2nd virtual function (index 1)
+    virtual ~Shape() = default;
+};
+
+class Rectangle : public Shape { public:
+    double w, h;
+
+public:
+    Rectangle(double width, double height) : w(width), h(height) {}
+    double area() const override { return w * h; }
+    const char * name() const override { return "Rectangle"; }
+};
+
+class Circle : public Shape {
+    double r;
+
+public:
+    Circle(double radius) : r(radius) {}
+    double area() const override { return M_PI * r * r; }
+    const char * name() const override { return "Circle"; }
+};
+
+// extern "C" factory functions to create C++ objects from C.
+extern "C" {
+Shape * create_rectangle(double w, double h) { return new Rectangle(w, h); }
+double fdfdsafdsa(Rectangle * shape){ return shape->w;}
+Shape * create_circle(double r) { return new Circle(r); }
+void destroy_shape(Shape * s) { delete s; }
+}

--- a/eg/cookbook/libs/shapes.cpp
+++ b/eg/cookbook/libs/shapes.cpp
@@ -16,7 +16,8 @@ public:
     virtual ~Shape() = default;
 };
 
-class Rectangle : public Shape { public:
+class Rectangle : public Shape {
+public:
     double w, h;
 
 public:
@@ -37,7 +38,6 @@ public:
 // extern "C" factory functions to create C++ objects from C.
 extern "C" {
 Shape * create_rectangle(double w, double h) { return new Rectangle(w, h); }
-double fdfdsafdsa(Rectangle * shape){ return shape->w;}
 Shape * create_circle(double r) { return new Circle(r); }
 void destroy_shape(Shape * s) { delete s; }
 }

--- a/include/infix/infix.h
+++ b/include/infix/infix.h
@@ -85,7 +85,7 @@
  */
 #define INFIX_MAJOR 0 /**< The major version number. Changes with incompatible API updates. */
 #define INFIX_MINOR 1 /**< The minor version number. Changes with new, backward-compatible features. */
-#define INFIX_PATCH 0 /**< The patch version number. Changes with backward-compatible bug fixes. */
+#define INFIX_PATCH 1 /**< The patch version number. Changes with backward-compatible bug fixes. */
 /** @} */
 
 // Define the POSIX source macro to ensure function declarations for shm_open,

--- a/include/infix/infix.h
+++ b/include/infix/infix.h
@@ -802,9 +802,10 @@ c23_nodiscard void * infix_library_get_symbol(infix_library_t *, const char *);
  * @param[in] symbol_name The name of the global variable.
  * @param[in] type_signature The `infix` signature string describing the variable's type.
  * @param[out] buffer A pointer to the destination buffer to receive the data.
+ * @param[in] registry An optional registry for resolving named types in the signature.
  * @return `INFIX_SUCCESS` on success, or an error code on failure.
  */
-c23_nodiscard infix_status infix_read_global(infix_library_t *, const char *, const char *, void *);
+c23_nodiscard infix_status infix_read_global(infix_library_t *, const char *, const char *, void *, infix_registry_t *);
 
 /**
  * @brief Writes data from a buffer into a global variable in a library.
@@ -812,9 +813,11 @@ c23_nodiscard infix_status infix_read_global(infix_library_t *, const char *, co
  * @param[in] symbol_name The name of the global variable.
  * @param[in] type_signature The `infix` signature string describing the variable's type.
  * @param[in] buffer A pointer to the source buffer containing the data to write.
+ * @param[in] registry An optional registry for resolving named types in the signature.
  * @return `INFIX_SUCCESS` on success, or an error code on failure.
  */
-c23_nodiscard infix_status infix_write_global(infix_library_t *, const char *, const char *, void *);
+c23_nodiscard infix_status
+infix_write_global(infix_library_t *, const char *, const char *, void *, infix_registry_t *);
 
 /** @} */  // end of exports_api group
 

--- a/src/common/infix_config.h
+++ b/src/common/infix_config.h
@@ -58,6 +58,14 @@
 #if defined(_WIN32)
 #define INFIX_OS_WINDOWS
 #include <windows.h>  // Included early for common types like SYSTEM_INFO, HANDLE, etc.
+// Compatibility shim for POSIX types not present in Clang/MSVC headers.
+#if !defined(__CYGWIN__)  // Cygwin provides its own full POSIX environment
+#include <stddef.h>       // For ptrdiff_t
+#ifndef ssize_t
+// Define ssize_t as ptrdiff_t, the standard signed counterpart to size_t.
+typedef ptrdiff_t ssize_t;
+#endif
+#endif
 #if defined(__MSYS__)
 #define INFIX_ENV_MSYS 1
 #elif defined(__CYGWIN__)

--- a/src/core/loader.c
+++ b/src/core/loader.c
@@ -143,12 +143,14 @@ c23_nodiscard void * infix_library_get_symbol(infix_library_t * lib, const char 
  * `"{double,double}"`).
  * @param[out] buffer A pointer to the destination buffer to receive the data. This buffer must be large enough to hold
  * the type described by the signature.
+ * @param[in] registry An optional registry for resolving named types in the signature.
  * @return `INFIX_SUCCESS` on success, or an error code on failure (e.g., symbol not found, invalid signature).
  */
 c23_nodiscard infix_status infix_read_global(infix_library_t * lib,
                                              const char * symbol_name,
                                              const char * type_signature,
-                                             void * buffer) {
+                                             void * buffer,
+                                             infix_registry_t * registry) {
     if (buffer == nullptr)
         return INFIX_ERROR_INVALID_ARGUMENT;
 
@@ -161,7 +163,7 @@ c23_nodiscard infix_status infix_read_global(infix_library_t * lib,
     // Parse the signature to get the type's size.
     infix_type * type = nullptr;
     infix_arena_t * arena = nullptr;
-    infix_status status = infix_type_from_signature(&type, &arena, type_signature, nullptr);
+    infix_status status = infix_type_from_signature(&type, &arena, type_signature, registry);
     if (status != INFIX_SUCCESS)
         return status;
 
@@ -188,12 +190,14 @@ c23_nodiscard infix_status infix_read_global(infix_library_t * lib,
  * @param[in] symbol_name The name of the global variable.
  * @param[in] type_signature The `infix` signature string describing the variable's type.
  * @param[in] buffer A pointer to the source buffer containing the data to write.
+ * @param[in] registry An optional registry for resolving named types in the signature.
  * @return `INFIX_SUCCESS` on success, or an error code on failure.
  */
 c23_nodiscard infix_status infix_write_global(infix_library_t * lib,
                                               const char * symbol_name,
                                               const char * type_signature,
-                                              void * buffer) {
+                                              void * buffer,
+                                              infix_registry_t * registry) {
     if (buffer == nullptr)
         return INFIX_ERROR_INVALID_ARGUMENT;
 
@@ -205,7 +209,7 @@ c23_nodiscard infix_status infix_write_global(infix_library_t * lib,
 
     infix_type * type = nullptr;
     infix_arena_t * arena = nullptr;
-    infix_status status = infix_type_from_signature(&type, &arena, type_signature, nullptr);
+    infix_status status = infix_type_from_signature(&type, &arena, type_signature, registry);
     if (status != INFIX_SUCCESS)
         return status;
 

--- a/src/core/signature.c
+++ b/src/core/signature.c
@@ -526,6 +526,17 @@ static infix_type * parse_primitive(parser_state * state) {
         return infix_type_create_primitive(INFIX_PRIMITIVE_FLOAT);
     if (consume_keyword(state, "longdouble"))
         return infix_type_create_primitive(INFIX_PRIMITIVE_LONG_DOUBLE);
+    if (consume_keyword(state, "size_t"))
+        return infix_type_create_primitive(sizeof(size_t) == 8 ? INFIX_PRIMITIVE_UINT64 : INFIX_PRIMITIVE_UINT32);
+    if (consume_keyword(state, "ssize_t"))
+        return infix_type_create_primitive(sizeof(ssize_t) == 8 ? INFIX_PRIMITIVE_SINT64 : INFIX_PRIMITIVE_SINT32);
+    // uchar.h types
+    if (consume_keyword(state, "char8_t"))
+        return infix_type_create_primitive(INFIX_PRIMITIVE_UINT8);
+    if (consume_keyword(state, "char16_t"))
+        return infix_type_create_primitive(INFIX_PRIMITIVE_UINT16);
+    if (consume_keyword(state, "char32_t"))
+        return infix_type_create_primitive(INFIX_PRIMITIVE_UINT32);
 
     // AVX convenience aliases
     if (consume_keyword(state, "m256d")) {

--- a/src/core/type_registry.c
+++ b/src/core/type_registry.c
@@ -477,7 +477,13 @@ c23_nodiscard infix_status infix_register_types(infix_registry_t * registry, con
             defs_found[num_defs_found].def_body_start = state.p;
             int nest_level = 0;
             const char * body_end = state.p;
-            while (*body_end != '\0' && !(*body_end == ';' && nest_level == 0)) {
+            while (*body_end != '\0' &&
+                   !(*body_end == ';' &&
+                     nest_level == 0)) {  // Explicitly check for and skip over the '->' token as a single unit.
+                if (*body_end == '-' && body_end[1] == '>') {
+                    body_end += 2;  // Advance the pointer past the entire token.
+                    continue;       // Continue to the next character in the loop.
+                }
                 if (*body_end == '{' || *body_end == '<' || *body_end == '(' || *body_end == '[')
                     nest_level++;
                 if (*body_end == '}' || *body_end == '>' || *body_end == ')' || *body_end == ']')


### PR DESCRIPTION

Really sanding down the rough edges this time around. This release includes significant ergonomic improvements to the high-level API.

### Added

- New Signature Keywords: Added keywords for common C and C++ types to improve signature readability and portability.
  - Added `size_t` and `ssize_t` as platform-dependent abstract types.
  - Added `char8_t`, `char16_t`, and `char32_t` as aliases for `uint8`, `uint16`, and `uint32` for better C++ interoperability.
- Cookbook Examples: Extracted all recipes from the cookbook documentation into a comprehensive suite of standalone, compilable example programs located in the `eg/cookbook/` directory.
- Advanced C++ Recipes: Added new, advanced cookbook recipes demonstrating direct, wrapper-free interoperability with core C++ features:
  - Calling C++ virtual functions by emulating v-table dispatch.
  - Bridging C-side stateful callbacks with C++ objects that expect `std::function` or similar callable objects.

### Changed

- Improved C++ Interoperability Recipes: Refined the C++ recipes to focus on direct interaction with C++ ABIs (mangled names, v-tables) rather than relying on C-style wrappers, showcasing more advanced use cases.
- Improved `wchar_t` Guidance: Added a dedicated cookbook recipe explaining the best-practice for handling `wchar_t` and other semantic string types via the Type Registry, ensuring signatures are unambiguous and introspectable.
- Enhanced High-Level API for Registered Types. The primary creation functions (`infix_forward_create`, `infix_forward_create_unbound`, `infix_reverse_create_callback`, and `infix_reverse_create_closure`) can now directly accept a registered named type as a signature.

    ```c
    // The high-level API now understands the "@Name" syntax directly.
    // Assume the registry already has "@Adder_add_fn = (*{ val: int }, int) -> int;"
    infix_reverse_create_callback(&ctx, "@Adder_add_fn", (void*)Adder_add, reg);
    ```

- The `infix_read_global` and `infix_write_global` functions now take an additional `infix_registry_t*` argument to support reading and writing global variables that are defined by a named type (e.g., `@MyStruct`).

### Fixed

- Fixed a critical parsing bug in `infix_register_types` that occurred when defining a function pointer type alias (e.g., `@MyFunc = (...) -> ...;`). The preliminary parser for finding definition boundaries would incorrectly interpret the `>` in the `->` token as a closing delimiter, corrupting its internal nesting level calculation. This resulted in an `INFIX_CODE_UNEXPECTED_TOKEN` error and prevented the registration of function pointer types. The parser is now context-aware and correctly handles the `->` token, allowing for the clean and correct registration of function pointer aliases as intended.