### PR TITLE
Forward declarations should create resolvable placeholder types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased] - 2025-12-xx
 
-Almost.
+This release should have more real-world usage fixes since I'm using it in Affix.pm and not just experimenting with different JIT forms.
+
+### Changed
+
+- Updated JIT validation logic to explicitly reject incomplete forward declarations, preventing the creation of broken trampolines.
 
 ### Fixed
 
-- Fixed signature positioning cache
+- Fixed signature positioning cache. The error messages will now (probably) point exactly where things are broken.
+- Fixed a critical bug in the Type Registry where forward declarations (e.g., `@Node;`) did not create valid placeholder types, causing subsequent references (e.g., `*@Node`) to fail resolution with `INFIX_CODE_UNRESOLVED_NAMED_TYPE`.
+- Fixed `infix_registry_print` to explicitly include forward declarations in the output, improving introspection visibility.
 
 ## [0.1.2] - 2025-11-26
 

--- a/include/infix/infix.h
+++ b/include/infix/infix.h
@@ -197,6 +197,7 @@ struct infix_type_t {
     size_t size;                  /**< The size of the type in bytes. */
     size_t alignment;             /**< The alignment requirement of the type in bytes. */
     bool is_arena_allocated;      /**< True if this type object lives in an arena and must be freed with it. */
+    bool is_incomplete;           /**< True if this is a forward declaration that has not yet been defined. */
     infix_arena_t * arena;        /**< A pointer to the arena that owns this type object, or nullptr if static. */
     size_t source_offset;         /**< The byte offset in the source signature where this type was defined. */
     /** @brief A union containing metadata specific to the type's category. */

--- a/src/core/signature.c
+++ b/src/core/signature.c
@@ -22,7 +22,7 @@
  * 1.  **Parsing:** It contains a hand-written recursive descent parser that transforms a
  *     human-readable signature string (e.g., `"({int, *char}) -> void"`) into an
  *     unresolved `infix_type` object graph. This is the **"Parse"** stage of the core
- *     data pipeline. The internal entry point for this stage is `_infix_parse_type_internal`.
+ *     data pipeline. The internal entry point for the "Parse" stage is `_infix_parse_type_internal`.
  *
  * 2.  **Printing:** It provides functions to serialize a fully resolved `infix_type`
  *     graph back into a canonical signature string. This is crucial for introspection,
@@ -1660,9 +1660,11 @@ c23_nodiscard infix_status infix_registry_print(char * buffer, size_t buffer_siz
                     goto end_print_loop;
                 }
                 _print(&state, "@%s = %s;\n", entry->name, type_body_buffer);
-                if (state.status != INFIX_SUCCESS)
-                    goto end_print_loop;
             }
+            else if (entry->is_forward_declaration)  // Explicitly print forward declarations
+                _print(&state, "@%s;\n", entry->name);
+            if (state.status != INFIX_SUCCESS)
+                goto end_print_loop;
         }
     }
 end_print_loop:;

--- a/src/core/types.c
+++ b/src/core/types.c
@@ -1007,6 +1007,7 @@ static infix_type * _copy_type_graph_to_arena_recursive(infix_arena_t * dest_are
     // Perform a shallow copy of the main struct, then recurse to deep copy child pointers.
     *dest_type = *src_type;
     dest_type->is_arena_allocated = true;
+    dest_type->is_incomplete = src_type->is_incomplete;
     dest_type->arena = dest_arena;  // The new type now belongs to the destination arena.
     // Deep copy the semantic name string, if it exists.
     if (src_type->name) {

--- a/src/jit/trampoline.c
+++ b/src/jit/trampoline.c
@@ -206,6 +206,8 @@ typedef struct visited_node_t {
 static bool _is_type_graph_resolved_recursive(const infix_type * type, visited_node_t * visited_head) {
     if (!type)
         return true;
+    if (type->is_incomplete)
+        return false;
     // Cycle detection: if we've seen this node before, we can assume it's resolved
     // for the purpose of this check, as we'll validate it on the first visit.
     for (visited_node_t * v = visited_head; v != NULL; v = v->next)

--- a/t/008_registry_introspection.c
+++ b/t/008_registry_introspection.c
@@ -11,7 +11,7 @@
  *
  * 1.  **`infix_registry_print`:**
  *     - Verifies that all *defined* types are serialized into a single string.
- *     - Confirms that undefined forward declarations are correctly omitted from the output.
+ *     - Confirms that undefined forward declarations are explicitly listed as incomplete types.
  *     - Checks that the function returns an error when the provided buffer is too small.
  *
  * 2.  **Registry Iterator (`infix_registry_iterator_*`)**:
@@ -19,7 +19,6 @@
  *     - Confirms that the correct number of types are found.
  *     - Checks that the `get_name` and `get_type` accessors return the correct data
  *       for each type.
- *     - Ensures that the iterator correctly skips over undefined forward declarations.
  */
 #define DBLTAP_IMPLEMENTATION
 #include "common/double_tap.h"
@@ -54,7 +53,8 @@ TEST {
             ok(strstr(buffer, "@Point = {x:double,y:double};") != NULL, "Output contains correct @Point definition");
             ok(strstr(buffer, "@Node = {value:sint32,next:*@Node};") != NULL,
                "Output contains correct @Node definition");
-            ok(strstr(buffer, "@FwdOnly") == NULL, "Output correctly omits undefined forward declaration");
+            // We now expect forward declarations to be printed as "@Name;\n"
+            ok(strstr(buffer, "@FwdOnly;") != NULL, "Output contains forward declaration @FwdOnly;");
         }
         else
             skip(4, "Skipping content checks due to print failure.");
@@ -84,10 +84,10 @@ TEST {
                     ok(type->category == INFIX_TYPE_STRUCT, "@Node has correct type");
                 }
                 else if (strcmp(name, "FwdOnly") == 0)
-                    fail("Iterator should not have found @FwdOnly");
+                    fail("Iterator should not have found @FwdOnly (it is incomplete)");
             }
         }
-        ok(count == 3, "Iterator found the correct number of defined types (3)");
+        ok(count == 3, "Iterator found the correct number of fully defined types (3)");
         ok(found_mask == 7, "All expected types (MyInt, Point, Node) were found by the iterator");
     }
     subtest("Lookup by Name API") {


### PR DESCRIPTION
Previously, forward declarations in the type registry (`@SDL_DisplayModeData;`) did not create a valid `infix_type` object until the full definition was parsed. This caused `INFIX_CODE_UNRESOLVED_NAMED_TYPE` errors when referencing the type (`*@SDL_DisplayModeData`) before it was fully defined, breaking mutually recursive type definitions.