### PR TITLE
Silence some compiler warnings

### DIFF
--- a/src/arch/x64/abi_sysv_x64.c
+++ b/src/arch/x64/abi_sysv_x64.c
@@ -1144,7 +1144,7 @@ static infix_status prepare_direct_forward_call_frame_sysv_x64(infix_arena_t * a
                                                                infix_direct_arg_handler_t * handlers,
                                                                void * target_fn) {
     // Use the standard classifier to determine the final ABI locations for all arguments.
-    infix_call_frame_layout * standard_layout = NULL;
+    infix_call_frame_layout * standard_layout = nullptr;
     infix_status status = prepare_forward_call_frame_sysv_x64(
         arena, &standard_layout, ret_type, arg_types, num_args, num_args, target_fn);
     if (status != INFIX_SUCCESS)

--- a/src/core/types.c
+++ b/src/core/types.c
@@ -1234,7 +1234,7 @@ static size_t _estimate_graph_size_recursive(infix_arena_t * temp_arena,
 size_t _infix_estimate_graph_size(infix_arena_t * temp_arena, const infix_type * type) {
     if (!temp_arena || !type)
         return 0;
-    estimate_visited_node_t * visited_head = NULL;
+    estimate_visited_node_t * visited_head = nullptr;
     return _estimate_graph_size_recursive(temp_arena, type, &visited_head);
 }
 // Public API: Introspection Functions


### PR DESCRIPTION
Just making some args retain const and adding explicit casts to make the compiler's job easier.