### PR TITLE
Fixed a critical file descriptor leak on POSIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will (I hope) be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased] - 2025-12-xx
+## [Unreleased] - 2025-12-xx
 
 This release should have more real-world usage fixes since I'm using it in Affix.pm and not just experimenting with different JIT forms.
 
@@ -15,6 +15,7 @@ This release should have more real-world usage fixes since I'm using it in Affix
 
 ### Fixed
 
+- Fixed a critical file descriptor leak on POSIX platforms (Linux/FreeBSD) where the file descriptor returned by `shm_open` was kept open for the lifetime of the trampoline, eventually hitting the process file descriptor limit (EMFILE). The descriptor is now closed immediately after mapping, as intended.
 - Fixed signature positioning cache. The error messages will now (probably) point exactly where things are broken.
 - Fixed a critical bug in the Type Registry where forward declarations (e.g., `@Node;`) did not create valid placeholder types, causing subsequent references (e.g., `*@Node`) to fail resolution with `INFIX_CODE_UNRESOLVED_NAMED_TYPE`.
 - Fixed `infix_registry_print` to explicitly include forward declarations in the output, improving introspection visibility.

--- a/include/infix/infix.h
+++ b/include/infix/infix.h
@@ -1224,12 +1224,17 @@ typedef enum {
  */
 typedef enum {
     // General Codes (0-99)
-    INFIX_CODE_SUCCESS = 0, /**< No error occurred. */
-    INFIX_CODE_UNKNOWN,     /**< An unspecified error occurred. */
+    INFIX_CODE_SUCCESS = 0,      /**< No error occurred. */
+    INFIX_CODE_UNKNOWN,          /**< An unspecified error occurred. */
+    INFIX_CODE_NULL_POINTER,     /**< A required pointer argument was NULL. */
+    INFIX_CODE_MISSING_REGISTRY, /**< A type registry was required but not provided. */
+
     // Allocation Codes (100-199)
     INFIX_CODE_OUT_OF_MEMORY = 100,       /**< A call to `malloc`, `calloc`, etc. failed. */
     INFIX_CODE_EXECUTABLE_MEMORY_FAILURE, /**< Failed to allocate executable memory from the OS. */
     INFIX_CODE_PROTECTION_FAILURE,        /**< Failed to change memory protection flags (e.g., `mprotect`). */
+    INFIX_CODE_INVALID_ALIGNMENT,         /**< An invalid alignment (0 or not power-of-two) was requested. */
+
     // Parser Codes (200-299)
     INFIX_CODE_UNEXPECTED_TOKEN = 200,   /**< Encountered an unexpected character or token. */
     INFIX_CODE_UNTERMINATED_AGGREGATE,   /**< A struct, union, or array was not properly closed. */
@@ -1238,12 +1243,15 @@ typedef enum {
     INFIX_CODE_INTEGER_OVERFLOW,         /**< An integer overflow occurred during layout calculation. */
     INFIX_CODE_RECURSION_DEPTH_EXCEEDED, /**< A type definition was too deeply nested. */
     INFIX_CODE_EMPTY_MEMBER_NAME,        /**< A named member was declared with an empty name. */
+    INFIX_CODE_EMPTY_SIGNATURE,          /**< The provided signature string was empty. */
+
     // ABI/Layout Codes (300-399)
     INFIX_CODE_UNSUPPORTED_ABI = 300, /**< The current platform's ABI is not supported by `infix`. */
     INFIX_CODE_TYPE_TOO_LARGE,        /**< A data type exceeded the ABI's size limits. */
     INFIX_CODE_UNRESOLVED_NAMED_TYPE, /**< A named type (`@Name`) was not found in the provided registry. */
     INFIX_CODE_INVALID_MEMBER_TYPE,   /**< An aggregate contained an illegal member type (e.g., `void`). */
     INFIX_CODE_LAYOUT_FAILED,         /**< The ABI layer failed to calculate a valid memory layout for a type. */
+
     // Library Loading Codes (400-499)
     INFIX_CODE_LIBRARY_NOT_FOUND = 400, /**< The requested dynamic library could not be found. */
     INFIX_CODE_SYMBOL_NOT_FOUND,        /**< The requested symbol was not found in the library. */

--- a/src/core/arena.c
+++ b/src/core/arena.c
@@ -120,7 +120,7 @@ c23_nodiscard void * infix_arena_alloc(infix_arena_t * arena, size_t size, size_
     // Alignment must be a power of two for the bitwise alignment trick to work.
     if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
         arena->error = true;
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);  // Programmatic error
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_INVALID_ALIGNMENT, 0);  // Programmatic error
         return nullptr;
     }
     infix_arena_t * current_block = arena;

--- a/src/core/error.c
+++ b/src/core/error.c
@@ -110,12 +110,18 @@ static const char * _get_error_message_for_code(infix_error_code_t code) {
         return "Success";
     case INFIX_CODE_UNKNOWN:
         return "An unknown error occurred";
+    case INFIX_CODE_NULL_POINTER:
+        return "A required pointer argument was NULL";
+    case INFIX_CODE_MISSING_REGISTRY:
+        return "A type registry was required but not provided";
     case INFIX_CODE_OUT_OF_MEMORY:
         return "Out of memory";
     case INFIX_CODE_EXECUTABLE_MEMORY_FAILURE:
         return "Failed to allocate executable memory";
     case INFIX_CODE_PROTECTION_FAILURE:
         return "Failed to change memory protection flags";
+    case INFIX_CODE_INVALID_ALIGNMENT:
+        return "Invalid alignment requested (must be power of two > 0)";
     case INFIX_CODE_UNEXPECTED_TOKEN:
         return "Unexpected token or character";
     case INFIX_CODE_UNTERMINATED_AGGREGATE:
@@ -130,6 +136,8 @@ static const char * _get_error_message_for_code(infix_error_code_t code) {
         return "Type definition is too deeply nested";
     case INFIX_CODE_EMPTY_MEMBER_NAME:
         return "Named type was declared with empty angle brackets";
+    case INFIX_CODE_EMPTY_SIGNATURE:
+        return "The provided signature string was empty";
     case INFIX_CODE_UNSUPPORTED_ABI:
         return "The current platform ABI is not supported";
     case INFIX_CODE_TYPE_TOO_LARGE:

--- a/src/core/signature.c
+++ b/src/core/signature.c
@@ -1082,22 +1082,36 @@ c23_nodiscard infix_status infix_signature_parse(const char * signature,
                                                  size_t * out_num_fixed_args,
                                                  infix_registry_t * registry) {
     _infix_clear_error();
-    if (!signature || !out_arena || !out_ret_type || !out_args || !out_num_args || !out_num_fixed_args) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+
+    //
+    if (!signature) {
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
+    if (*signature == '\0') {
+        _infix_set_error(INFIX_CATEGORY_PARSER, INFIX_CODE_EMPTY_SIGNATURE, 0);
+        return INFIX_ERROR_INVALID_ARGUMENT;
+    }
+    if (!out_arena || !out_ret_type || !out_args || !out_num_args || !out_num_fixed_args) {
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
+        return INFIX_ERROR_INVALID_ARGUMENT;
+    }
+
     g_infix_last_signature_context = signature;
-    // 1. "Parse" stage
+
+    // Parse stage
     infix_type * raw_func_type = nullptr;
     infix_arena_t * parser_arena = nullptr;
     infix_status status = _infix_parse_type_internal(&raw_func_type, &parser_arena, signature);
     if (status != INFIX_SUCCESS)
         return status;
+
     if (raw_func_type->category != INFIX_TYPE_REVERSE_TRAMPOLINE) {
         infix_arena_destroy(parser_arena);
         _infix_set_error(INFIX_CATEGORY_PARSER, INFIX_CODE_UNEXPECTED_TOKEN, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
+
     // Create final arena
     *out_arena = infix_arena_create(8192);
     if (!*out_arena) {
@@ -1105,7 +1119,8 @@ c23_nodiscard infix_status infix_signature_parse(const char * signature,
         _infix_set_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_OUT_OF_MEMORY, 0);
         return INFIX_ERROR_ALLOCATION_FAILED;
     }
-    // 2. "Copy" stage
+
+    // "Copy" stage
     infix_type * final_func_type = _copy_type_graph_to_arena(*out_arena, raw_func_type);
     infix_arena_destroy(parser_arena);
     if (!final_func_type) {
@@ -1114,7 +1129,8 @@ c23_nodiscard infix_status infix_signature_parse(const char * signature,
         _infix_set_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_OUT_OF_MEMORY, 0);
         return INFIX_ERROR_ALLOCATION_FAILED;
     }
-    // 3. "Resolve" and 4. "Layout" stages
+
+    // Resolve and layout stages
     status = _infix_resolve_type_graph_inplace(&final_func_type, registry);
     if (status != INFIX_SUCCESS) {
         infix_arena_destroy(*out_arena);
@@ -1122,6 +1138,7 @@ c23_nodiscard infix_status infix_signature_parse(const char * signature,
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     _infix_type_recalculate_layout(final_func_type);
+
     // Unpack the results for the caller from the final, processed function type object.
     *out_ret_type = final_func_type->meta.func_ptr_info.return_type;
     *out_args = final_func_type->meta.func_ptr_info.args;
@@ -1129,6 +1146,7 @@ c23_nodiscard infix_status infix_signature_parse(const char * signature,
     *out_num_fixed_args = final_func_type->meta.func_ptr_info.num_fixed_args;
     return INFIX_SUCCESS;
 }
+
 // Type Printing Logic
 /**
  * @internal

--- a/src/core/signature.c
+++ b/src/core/signature.c
@@ -968,8 +968,12 @@ static infix_status parse_function_signature_details(parser_state * state,
 c23_nodiscard infix_status _infix_parse_type_internal(infix_type ** out_type,
                                                       infix_arena_t ** out_arena,
                                                       const char * signature) {
-    if (!out_type || !out_arena || !signature || *signature == '\0') {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+    if (!out_type || !out_arena) {
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
+        return INFIX_ERROR_INVALID_ARGUMENT;
+    }
+    if (!signature || *signature == '\0') {
+        _infix_set_error(INFIX_CATEGORY_PARSER, INFIX_CODE_EMPTY_SIGNATURE, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     // The top-level public API is responsible for setting g_infix_last_signature_context.
@@ -1539,7 +1543,7 @@ c23_nodiscard infix_status infix_type_print(char * buffer,
                                             infix_print_dialect_t dialect) {
     _infix_clear_error();
     if (!buffer || buffer_size == 0 || !type) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     printer_state state = {buffer, buffer_size, INFIX_SUCCESS};
@@ -1587,7 +1591,7 @@ c23_nodiscard infix_status infix_function_print(char * buffer,
                                                 infix_print_dialect_t dialect) {
     _infix_clear_error();
     if (!buffer || buffer_size == 0 || !ret_type || (num_args > 0 && !args)) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     printer_state state = {buffer, buffer_size, INFIX_SUCCESS};

--- a/src/core/type_registry.c
+++ b/src/core/type_registry.c
@@ -183,7 +183,7 @@ c23_nodiscard infix_registry_t * infix_registry_create(void) {
 c23_nodiscard infix_registry_t * infix_registry_create_in_arena(infix_arena_t * arena) {
     _infix_clear_error();
     if (!arena) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return nullptr;
     }
     infix_registry_t * registry = infix_malloc(sizeof(infix_registry_t));
@@ -428,7 +428,7 @@ static char * _registry_parser_parse_name(_registry_parser_state_t * state, char
 c23_nodiscard infix_status infix_register_types(infix_registry_t * registry, const char * definitions) {
     _infix_clear_error();
     if (!registry || !definitions) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     _registry_parser_state_t state = {.p = definitions, .start = definitions};

--- a/src/core/types.c
+++ b/src/core/types.c
@@ -429,7 +429,7 @@ c23_nodiscard infix_status infix_type_create_pointer_to(infix_arena_t * arena,
                                                         infix_type ** out_type,
                                                         infix_type * pointee_type) {
     if (!out_type || !pointee_type) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     infix_type * type = infix_arena_calloc(arena, 1, sizeof(infix_type), _Alignof(infix_type));
@@ -460,7 +460,7 @@ c23_nodiscard infix_status infix_type_create_array(infix_arena_t * arena,
                                                    infix_type * element_type,
                                                    size_t num_elements) {
     if (out_type == nullptr || element_type == nullptr) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     if (element_type->size > 0 && num_elements > SIZE_MAX / element_type->size) {
@@ -497,7 +497,7 @@ c23_nodiscard infix_status infix_type_create_flexible_array(infix_arena_t * aren
                                                             infix_type ** out_type,
                                                             infix_type * element_type) {
     if (out_type == nullptr || element_type == nullptr) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     // Flexible arrays of incomplete types (size 0) are generally not allowed.
@@ -540,7 +540,7 @@ c23_nodiscard infix_status infix_type_create_enum(infix_arena_t * arena,
                                                   infix_type ** out_type,
                                                   infix_type * underlying_type) {
     if (out_type == nullptr || underlying_type == nullptr) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     if (underlying_type->category != INFIX_TYPE_PRIMITIVE ||
@@ -574,7 +574,7 @@ c23_nodiscard infix_status infix_type_create_complex(infix_arena_t * arena,
                                                      infix_type ** out_type,
                                                      infix_type * base_type) {
     if (out_type == nullptr || base_type == nullptr || (!is_float(base_type) && !is_double(base_type))) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     infix_type * type = infix_arena_calloc(arena, 1, sizeof(infix_type), _Alignof(infix_type));
@@ -605,7 +605,7 @@ c23_nodiscard infix_status infix_type_create_vector(infix_arena_t * arena,
                                                     infix_type * element_type,
                                                     size_t num_elements) {
     if (out_type == nullptr || element_type == nullptr || element_type->category != INFIX_TYPE_PRIMITIVE) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     if (element_type->size > 0 && num_elements > SIZE_MAX / element_type->size) {
@@ -750,8 +750,12 @@ c23_nodiscard infix_status infix_type_create_packed_struct(infix_arena_t * arena
                                                            size_t alignment,
                                                            infix_struct_member * members,
                                                            size_t num_members) {
-    if (out_type == nullptr || (num_members > 0 && members == nullptr) || alignment == 0) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+    if (out_type == nullptr || (num_members > 0 && members == nullptr)) {
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
+        return INFIX_ERROR_INVALID_ARGUMENT;
+    }
+    if (alignment == 0) {
+        _infix_set_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_INVALID_ALIGNMENT, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     infix_type * type = infix_arena_calloc(arena, 1, sizeof(infix_type), _Alignof(infix_type));
@@ -797,7 +801,7 @@ c23_nodiscard infix_status infix_type_create_named_reference(infix_arena_t * are
                                                              const char * name,
                                                              infix_aggregate_category_t agg_cat) {
     if (out_type == nullptr || name == nullptr) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     infix_type * type = infix_arena_calloc(arena, 1, sizeof(infix_type), _Alignof(infix_type));

--- a/src/jit/executor.c
+++ b/src/jit/executor.c
@@ -213,8 +213,11 @@ c23_nodiscard infix_executable_t infix_executable_alloc(size_t size) {
 #if defined(INFIX_OS_WINDOWS)
     // Windows: Single-mapping W^X. Allocate as RW, later change to RX via VirtualProtect.
     void * code = VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-    if (code == nullptr)
+    if (code == nullptr) {
+        _infix_set_system_error(
+            INFIX_CATEGORY_ALLOCATION, INFIX_CODE_EXECUTABLE_MEMORY_FAILURE, GetLastError(), nullptr);
         return exec;
+    }
     exec.rw_ptr = code;
     exec.rx_ptr = code;
 #elif defined(INFIX_OS_MACOS) || defined(INFIX_OS_ANDROID) || defined(INFIX_OS_OPENBSD) || defined(INFIX_OS_DRAGONFLY)
@@ -246,16 +249,23 @@ c23_nodiscard infix_executable_t infix_executable_alloc(size_t size) {
             close(fd);
         }
     }
-    if (code == MAP_FAILED)
+    if (code == MAP_FAILED) {
+        _infix_set_system_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_EXECUTABLE_MEMORY_FAILURE, errno, nullptr);
         return exec;
+    }
     exec.rw_ptr = code;
     exec.rx_ptr = code;
 #else
     // Dual-mapping POSIX platforms (e.g., Linux, FreeBSD). Create two separate views of the same memory.
     exec.shm_fd = shm_open_anonymous();
-    if (exec.shm_fd < 0)
+    if (exec.shm_fd < 0) {
+        _infix_set_system_error(
+            INFIX_CATEGORY_ALLOCATION, INFIX_CODE_EXECUTABLE_MEMORY_FAILURE, errno, "shm_open failed");
         return exec;
+    }
     if (ftruncate(exec.shm_fd, size) != 0) {
+        _infix_set_system_error(
+            INFIX_CATEGORY_ALLOCATION, INFIX_CODE_EXECUTABLE_MEMORY_FAILURE, errno, "ftruncate failed");
         close(exec.shm_fd);
         return exec;
     }
@@ -366,6 +376,8 @@ c23_nodiscard bool infix_executable_make_executable(infix_executable_t exec) {
 #if defined(INFIX_OS_WINDOWS)
     // Finalize permissions to Read+Execute.
     result = VirtualProtect(exec.rw_ptr, exec.size, PAGE_EXECUTE_READ, &(DWORD){0});
+    if (!result)
+        _infix_set_system_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_PROTECTION_FAILURE, GetLastError(), nullptr);
 #elif defined(INFIX_OS_MACOS)
 #if INFIX_MACOS_SECURE_JIT_AVAILABLE  // Placeholder
     static bool g_use_secure_jit_path = false;
@@ -381,9 +393,13 @@ c23_nodiscard bool infix_executable_make_executable(infix_executable_t exec) {
         // However, the current logic does this change via `pthread_jit_write_protect_np`
         // within the allocator itself. For now, this is a placeholder for that logic.
         result = (mprotect(exec.rw_ptr, exec.size, PROT_READ | PROT_EXEC) == 0);
+    if (!result)
+        _infix_set_system_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_PROTECTION_FAILURE, errno, nullptr);
 #elif defined(INFIX_OS_ANDROID) || defined(INFIX_OS_OPENBSD) || defined(INFIX_OS_DRAGONFLY)
     // Other single-mapping POSIX platforms use mprotect.
     result = (mprotect(exec.rw_ptr, exec.size, PROT_READ | PROT_EXEC) == 0);
+    if (!result)
+        _infix_set_system_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_PROTECTION_FAILURE, errno, nullptr);
 #else
     // On dual-mapping platforms, the RX mapping is already executable. This is a no-op.
     result = true;
@@ -410,6 +426,8 @@ c23_nodiscard infix_protected_t infix_protected_alloc(size_t size) {
         return prot;
 #if defined(INFIX_OS_WINDOWS)
     prot.rw_ptr = VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    if (!prot.rw_ptr)
+        _infix_set_system_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_OUT_OF_MEMORY, GetLastError(), nullptr);
 #else
 #if defined(MAP_ANON)
     prot.rw_ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
@@ -422,8 +440,10 @@ c23_nodiscard infix_protected_t infix_protected_alloc(size_t size) {
         close(fd);
     }
 #endif
-    if (prot.rw_ptr == MAP_FAILED)
+    if (prot.rw_ptr == MAP_FAILED) {
+        _infix_set_system_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_OUT_OF_MEMORY, errno, nullptr);
         prot.rw_ptr = nullptr;
+    }
 #endif
     if (prot.rw_ptr)
         prot.size = size;
@@ -460,8 +480,12 @@ c23_nodiscard bool infix_protected_make_readonly(infix_protected_t prot) {
     bool result = false;
 #if defined(INFIX_OS_WINDOWS)
     result = VirtualProtect(prot.rw_ptr, prot.size, PAGE_READONLY, &(DWORD){0});
+    if (!result)
+        _infix_set_system_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_PROTECTION_FAILURE, GetLastError(), nullptr);
 #else
     result = (mprotect(prot.rw_ptr, prot.size, PROT_READ) == 0);
+    if (!result)
+        _infix_set_system_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_PROTECTION_FAILURE, errno, nullptr);
 #endif
     return result;
 }

--- a/src/jit/trampoline.c
+++ b/src/jit/trampoline.c
@@ -318,7 +318,7 @@ c23_nodiscard infix_status _infix_forward_create_impl(infix_forward_t ** out_tra
                                                       size_t num_fixed_args,
                                                       void * target_fn) {
     if (out_trampoline == nullptr || return_type == nullptr || (arg_types == nullptr && num_args > 0)) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     // Pre-flight check: ensure all types are resolved before passing to ABI layer.
@@ -465,7 +465,7 @@ c23_nodiscard infix_status _infix_forward_create_direct_impl(infix_forward_t ** 
                                                              infix_direct_arg_handler_t * handlers) {
     // 1. Validation and Setup
     if (!out_trampoline || !return_type || (!arg_types && num_args > 0) || !target_fn || !handlers) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
 
@@ -689,7 +689,7 @@ static infix_status _infix_reverse_create_internal(infix_reverse_t ** out_contex
                                                    void * user_data,
                                                    bool is_callback) {
     if (out_context == nullptr || return_type == nullptr || num_fixed_args > num_args) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     // Pre-flight check: ensure all types are fully resolved.
@@ -917,7 +917,7 @@ c23_nodiscard infix_status infix_forward_create_in_arena(infix_forward_t ** out_
                                                          infix_registry_t * registry) {
     _infix_clear_error();
     if (!signature) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
     infix_arena_t * arena = nullptr;
@@ -928,7 +928,8 @@ c23_nodiscard infix_status infix_forward_create_in_arena(infix_forward_t ** out_
     infix_status status;
     if (signature[0] == '@') {
         if (registry == nullptr) {
-            _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);  // Using @Name requires a registry
+            _infix_set_error(
+                INFIX_CATEGORY_GENERAL, INFIX_CODE_MISSING_REGISTRY, 0);  // Using @Name requires a registry
             return INFIX_ERROR_INVALID_ARGUMENT;
         }
         const infix_type * func_type = infix_registry_lookup_type(registry, &signature[1]);
@@ -1006,7 +1007,7 @@ c23_nodiscard infix_status infix_forward_create_direct(infix_forward_t ** out_tr
                                                        infix_registry_t * registry) {
     _infix_clear_error();
     if (!signature || !target_function || !handlers) {
-        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_UNKNOWN, 0);
+        _infix_set_error(INFIX_CATEGORY_GENERAL, INFIX_CODE_NULL_POINTER, 0);
         return INFIX_ERROR_INVALID_ARGUMENT;
     }
 

--- a/src/jit/trampoline.c
+++ b/src/jit/trampoline.c
@@ -156,6 +156,7 @@ void code_buffer_append(code_buffer * buf, const void * data, size_t len) {
         return;
     if (len > SIZE_MAX - buf->size) {  // Overflow check
         buf->error = true;
+        _infix_set_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_INTEGER_OVERFLOW, 0);
         return;
     }
     if (buf->size + len > buf->capacity) {
@@ -163,6 +164,7 @@ void code_buffer_append(code_buffer * buf, const void * data, size_t len) {
         while (new_capacity < buf->size + len) {
             if (new_capacity > SIZE_MAX / 2) {  // Overflow check
                 buf->error = true;
+                _infix_set_error(INFIX_CATEGORY_ALLOCATION, INFIX_CODE_INTEGER_OVERFLOW, 0);
                 return;
             }
             new_capacity *= 2;
@@ -170,6 +172,7 @@ void code_buffer_append(code_buffer * buf, const void * data, size_t len) {
         void * new_code = infix_arena_alloc(buf->arena, new_capacity, 16);
         if (new_code == nullptr) {
             buf->error = true;
+            // infix_arena_alloc already sets INFIX_CODE_OUT_OF_MEMORY, so we don't need to override it here
             return;
         }
         infix_memcpy(new_code, buf->code, buf->size);

--- a/t/861_error_reporting.c
+++ b/t/861_error_reporting.c
@@ -1,0 +1,101 @@
+/**
+ * @file 861_error_reporting_regression.c
+ * @brief Unit tests verifying specific error codes for invalid inputs.
+ * @ingroup test_suite
+ *
+ * @details This test ensures that the library reports specific, useful error codes
+ * (like INFIX_CODE_NULL_POINTER, INFIX_CODE_EMPTY_SIGNATURE, etc.) instead of
+ * generic unknown errors when the API is misused. This prevents the "silent failure"
+ * or "error code 1" scenarios encountered in production.
+ */
+#define DBLTAP_IMPLEMENTATION
+#include "common/double_tap.h"
+#include <infix/infix.h>
+
+TEST {
+    plan(4);
+
+    subtest("Signature parser input validation") {
+        plan(6);
+        infix_arena_t * arena = NULL;
+        infix_type * ret_type = NULL;
+        infix_function_argument * args = NULL;
+        size_t n_args, n_fixed;
+        infix_status status;
+
+        // NULL signature
+        status = infix_signature_parse(NULL, &arena, &ret_type, &args, &n_args, &n_fixed, NULL);
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT,
+           "infix_signature_parse(NULL, ...) returns INFIX_ERROR_INVALID_ARGUMENT");
+        ok(infix_get_last_error().code == INFIX_CODE_NULL_POINTER, "Error code is INFIX_CODE_NULL_POINTER");
+
+        // Empty signature
+        status = infix_signature_parse("", &arena, &ret_type, &args, &n_args, &n_fixed, NULL);
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT,
+           "infix_signature_parse(\"\", ...) returns INFIX_ERROR_INVALID_ARGUMENT");
+        ok(infix_get_last_error().code == INFIX_CODE_EMPTY_SIGNATURE, "Error code is INFIX_CODE_EMPTY_SIGNATURE");
+
+        // NULL output pointers
+        // Note: valid signature, invalid outputs
+        status = infix_signature_parse("()->void", NULL, NULL, NULL, NULL, NULL, NULL);
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT,
+           "infix_signature_parse(..., NULLs) returns INFIX_ERROR_INVALID_ARGUMENT");
+        ok(infix_get_last_error().code == INFIX_CODE_NULL_POINTER, "Error code is INFIX_CODE_NULL_POINTER");
+    }
+
+    subtest("Trampoline creation validation") {
+        plan(4);
+        infix_forward_t * t = NULL;
+        infix_status status;
+
+        // NULL signature in forward create
+        status = infix_forward_create(&t, NULL, NULL, NULL);
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT,
+           "infix_forward_create(..., NULL, ...) returns INFIX_ERROR_INVALID_ARGUMENT");
+        ok(infix_get_last_error().code == INFIX_CODE_NULL_POINTER, "Error code is INFIX_CODE_NULL_POINTER");
+
+        // Missing registry for named type
+        status = infix_forward_create(&t, "@MyType", NULL, NULL);  // Registry is NULL
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT,
+           "infix_forward_create(..., \"@MyType\", ..., NULL) returns INFIX_ERROR_INVALID_ARGUMENT");
+        ok(infix_get_last_error().code == INFIX_CODE_MISSING_REGISTRY, "Error code is INFIX_CODE_MISSING_REGISTRY");
+    }
+
+    subtest("Manual API validation (NULL ptrs)") {
+        plan(6);
+        infix_arena_t * arena = infix_arena_create(1024);
+        infix_type * out_type = NULL;
+        infix_status status;
+
+        // Pointer to NULL
+        status = infix_type_create_pointer_to(arena, &out_type, NULL);
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT, "infix_type_create_pointer_to(..., NULL) -> ERROR");
+        ok(infix_get_last_error().code == INFIX_CODE_NULL_POINTER, "Code: INFIX_CODE_NULL_POINTER");
+
+        // Array of NULL type
+        status = infix_type_create_array(arena, &out_type, NULL, 10);
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT, "infix_type_create_array(..., NULL, ...) -> ERROR");
+        ok(infix_get_last_error().code == INFIX_CODE_NULL_POINTER, "Code: INFIX_CODE_NULL_POINTER");
+
+        // Enum of NULL base
+        status = infix_type_create_enum(arena, &out_type, NULL);
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT, "infix_type_create_enum(..., NULL) -> ERROR");
+        ok(infix_get_last_error().code == INFIX_CODE_NULL_POINTER, "Code: INFIX_CODE_NULL_POINTER");
+
+        infix_arena_destroy(arena);
+    }
+
+    subtest("Manual API validation (alignment/packing)") {
+        plan(2);
+        infix_arena_t * arena = infix_arena_create(1024);
+        infix_type * out_type = NULL;
+        infix_struct_member members[] = {{"a", infix_type_create_primitive(INFIX_PRIMITIVE_SINT32), 0, 0, 0, false}};
+
+        // 0 Alignment is invalid
+        infix_status status = infix_type_create_packed_struct(arena, &out_type, 4, 0, members, 1);
+        ok(status == INFIX_ERROR_INVALID_ARGUMENT, "infix_type_create_packed_struct(..., align=0, ...) -> ERROR");
+        ok(infix_get_last_error().code == INFIX_CODE_INVALID_ALIGNMENT, "Code: INFIX_CODE_INVALID_ALIGNMENT");
+
+        infix_arena_destroy(arena);
+    }
+}


### PR DESCRIPTION
We were leaving file descriptors open with every dual mapped trampoline we created.