### PR TITLE
Prevent semantic erasure of char types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `infix` will (I hope) be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- The string parser now preserves names for character-specific primitives (`wchar_t`, `char16_t`, `char32_t`, and `char8_t`). This prevents semantic erasure where these types were previously indistinguishable from raw integers.
+- Updated `infix_type_get_name()` to return the alias name for these specific primitives, enabling high-level marshallers to correctly identify string buffers without relying on fragile `sizeof()` heuristics.
+
 ## [0.1.6] - 2026-02-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to `infix` will (I hope) be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.7] - 2026-03-30
 
-### Added
+### Changed
+
 - The string parser now preserves names for character-specific primitives (`wchar_t`, `char16_t`, `char32_t`, and `char8_t`). This prevents semantic erasure where these types were previously indistinguishable from raw integers.
 - Updated `infix_type_get_name()` to return the alias name for these specific primitives, enabling high-level marshallers to correctly identify string buffers without relying on fragile `sizeof()` heuristics.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -239,6 +239,11 @@ These functions work for both `infix_forward_t*` and `infix_reverse_t*` handles.
 
 *   `infix_status infix_type_from_signature(...)`: Parses a signature string into a detailed `infix_type` graph.
 *   `const char* infix_type_get_name(const infix_type* type)`: Returns the semantic alias of a type (e.g., "MyInt"), or `NULL` if anonymous.
+  *   **For Registry Types:** Returns the name used in the registry (e.g., "MyStruct").
+  *   **For Built-in Aliases:** Returns the specific keyword used in the signature (e.g., "wchar_t", "char16_t", "size_t").
+  *   **For Raw Primitives:** Returns `NULL` for standard types like `sint32` or `double`.
+
+ **Usage Note:** This is the recommended way to detect if an array should be marshalled as a string. Check if the element type's name is "wchar_t" or "char16_t" rather than checking its size.
 *   `infix_type_category infix_type_get_category(const infix_type* type)`: Returns the fundamental category (e.g., `INFIX_TYPE_STRUCT`).
 *   `size_t infix_type_get_size(const infix_type* type)`: Returns the size of the type in bytes.
 *   `size_t infix_type_get_alignment(const infix_type* type)`: Returns the alignment requirement in bytes.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -270,7 +270,7 @@ This section provides a low-level comparison of the ABIs supported by `infix`.
 
 ---
 
-## 5. Maintainer's Debugging Guide
+## 6. Maintainer's Debugging Guide
 
 ### Method 1: Static Analysis with `infix_dump_hex`
 The simplest way to see what the JIT is producing is to enable `INFIX_DEBUG_ENABLED=1` in your build. This will trigger a hexdump of the generated machine code after every trampoline creation.

--- a/docs/signatures.md
+++ b/docs/signatures.md
@@ -50,6 +50,7 @@ These keywords represent standard C types whose size can vary by platform. They 
 | `longdouble`    | `long double`        | Varies              | 80-bit (x86), 128-bit (AArch64), or 64-bit (MSVC) float. Use with caution.  |
 | `size_t`        | `size_t`             | 32 or 64 bits       | **Platform-dependent.** 32 bits on 64-bit Windows, 64 bits on Linux/macOS.  |
 | `ssize_t`       | `ssize_t`            | 32 or 64 bits       | **Platform-dependent.** 32 bits on 64-bit Windows, 64 bits on Linux/macOS.  |
+| `wchar_t`       | `wchar_t`            | 16 or 32 bits       | **Platform-dependent.** 16 bits on 32-bit Windows, 64 bits on Linux/macOS.  |
 
 #### Tier 2: Explicit Fixed-Width Types (Recommended)
 
@@ -142,6 +143,17 @@ These syntax elements allow you to build complex types from simpler ones.
 `infix` supports C++-style namespaces and nested scopes using the `::` operator. This is used in the Type Registry to define types that live within a namespace, and it is recognized by the C++ mangling dialects to generate correct ABI-compliant symbols.
 
 *   **Example:** `@Graphics::Math::Vector3`
+
+### 2.6 Built-in Aliases vs. Registry Aliases
+
+While most custom names in `infix` require a Registry (`@Name`), certain built-in aliases are handled natively by the parser to preserve their semantic meaning for FFI marshallers.
+
+*   **Registry Aliases (`@MyType`):** Require an `infix_registry_t`. These are deep-copied and resolved during the resolution stage.
+*   **Built-in Aliases (`wchar_t`, `size_t`, etc.):** These resolve directly to `PRIMITIVE` types but **retain their name**.
+
+#### Why this matters for Strings
+
+In C, a `wchar_t[]` and an `int32_t[]` might look identical in memory on Linux (both are arrays of 4-byte integers). However, by using the keyword `wchar_t`, `infix` preserves that name in the metadata. High-level languages (like Perl or Python) can use `infix_type_get_name()` to see the string "wchar_t" and automatically treat the buffer as a string instead of a list of numbers.
 
 ---
 

--- a/include/infix/infix.h
+++ b/include/infix/infix.h
@@ -82,7 +82,7 @@
  */
 #define INFIX_MAJOR 0 /**< The major version number. Changes with incompatible API updates. */
 #define INFIX_MINOR 1 /**< The minor version number. Changes with new, backward-compatible features. */
-#define INFIX_PATCH 6 /**< The patch version number. Changes with backward-compatible bug fixes. */
+#define INFIX_PATCH 7 /**< The patch version number. Changes with backward-compatible bug fixes. */
 
 #if defined(__has_c_attribute)
 #define _INFIX_HAS_C_ATTRIBUTE(x) __has_c_attribute(x)

--- a/src/core/signature.c
+++ b/src/core/signature.c
@@ -449,6 +449,30 @@ static infix_type * parse_packed_struct(parser_state * state) {
         return nullptr;
     return packed_type;
 }
+/**
+ * @internal
+ * @brief Helper to preserve the semantic name of C-style primitive aliases.
+ * @param state The parser's state.
+ * @param id The primitive type id.
+ * @param name The string the user used to describe this type.
+ */
+static infix_type * _create_named_primitive(parser_state * state, infix_primitive_type_id id, const char * name) {
+    infix_type * t = infix_arena_calloc(state->arena, 1, sizeof(infix_type), _Alignof(infix_type));
+    if (!t)
+        return nullptr;
+
+    *t = *infix_type_create_primitive(id);
+    t->is_arena_allocated = true;
+    t->arena = state->arena;
+
+    size_t len = strlen(name) + 1;
+    char * arena_name = infix_arena_alloc(state->arena, len, 1);
+    if (arena_name) {
+        infix_memcpy(arena_name, name, len);
+        t->name = arena_name;
+    }
+    return t;
+}
 // Main Parser Logic
 /**
  * @internal
@@ -524,13 +548,16 @@ INFIX_INTERNAL infix_type * parse_primitive(parser_state * state) {
         return infix_type_create_primitive(sizeof(size_t) == 8 ? INFIX_PRIMITIVE_UINT64 : INFIX_PRIMITIVE_UINT32);
     if (consume_keyword(state, "ssize_t"))
         return infix_type_create_primitive(sizeof(ssize_t) == 8 ? INFIX_PRIMITIVE_SINT64 : INFIX_PRIMITIVE_SINT32);
-    // uchar.h types
+    // Explicit Character Types
     if (consume_keyword(state, "char8_t"))
-        return infix_type_create_primitive(INFIX_PRIMITIVE_UINT8);
+        return _create_named_primitive(state, INFIX_PRIMITIVE_UINT8, "char8_t");
     if (consume_keyword(state, "char16_t"))
-        return infix_type_create_primitive(INFIX_PRIMITIVE_UINT16);
+        return _create_named_primitive(state, INFIX_PRIMITIVE_UINT16, "char16_t");
     if (consume_keyword(state, "char32_t"))
-        return infix_type_create_primitive(INFIX_PRIMITIVE_UINT32);
+        return _create_named_primitive(state, INFIX_PRIMITIVE_UINT32, "char32_t");
+    if (consume_keyword(state, "wchar_t"))
+        return _create_named_primitive(
+            state, sizeof(wchar_t) == 2 ? INFIX_PRIMITIVE_UINT16 : INFIX_PRIMITIVE_SINT32, "wchar_t");
     // AVX convenience aliases
     if (consume_keyword(state, "m256d")) {
         infix_type * type = nullptr;
@@ -1262,7 +1289,12 @@ static void _infix_type_print_signature_recursive(printer_state * state, const i
     }
     // If the type has a semantic name, always prefer printing it.
     if (type->name) {
-        _print(state, "@%s", type->name);
+        // Only prepend '@' if it is an aggregate or named reference.
+        // Primitives like WChar or aliases like size_t should not get '@'.
+        if (type->category == INFIX_TYPE_PRIMITIVE || type->category == INFIX_TYPE_VOID)
+            _print(state, "%s", type->name);
+        else
+            _print(state, "@%s", type->name);
         return;
     }
     switch (type->category) {
@@ -1458,6 +1490,63 @@ static void _infix_type_print_itanium_recursive(printer_state * state, const inf
         return;
     }
 
+    // These built-in types must ALWAYS use ABI codes, ignoring any name aliases.
+    if (type->category == INFIX_TYPE_VOID) {
+        _print(state, "v");
+        return;
+    }
+
+    if (type->category == INFIX_TYPE_PRIMITIVE) {
+        switch (type->meta.primitive_id) {
+        case INFIX_PRIMITIVE_BOOL:
+            _print(state, "b");
+            return;
+        case INFIX_PRIMITIVE_SINT8:  // signed char
+            _print(state, "a");
+            return;
+        case INFIX_PRIMITIVE_UINT8:  // unsigned char
+            _print(state, "h");
+            return;
+        case INFIX_PRIMITIVE_SINT16:  // short
+            _print(state, "s");
+            return;
+        case INFIX_PRIMITIVE_UINT16:  // unsigned short
+            _print(state, "t");
+            return;
+        case INFIX_PRIMITIVE_SINT32:  // int
+            _print(state, "i");
+            return;
+        case INFIX_PRIMITIVE_UINT32:  // unsigned int
+            _print(state, "j");
+            return;
+        case INFIX_PRIMITIVE_SINT64:  // long long
+            _print(state, "x");
+            return;
+        case INFIX_PRIMITIVE_UINT64:  // unsigned long long
+            _print(state, "y");
+            return;
+        case INFIX_PRIMITIVE_SINT128:  // __int128
+            _print(state, "n");
+            return;
+        case INFIX_PRIMITIVE_UINT128:  // unsigned __int128
+            _print(state, "o");
+            return;
+        case INFIX_PRIMITIVE_FLOAT16:  // half-precision float (IEEE 754)
+            _print(state, "Dh");
+            return;
+        case INFIX_PRIMITIVE_FLOAT:
+            _print(state, "f");
+            return;
+        case INFIX_PRIMITIVE_DOUBLE:
+            _print(state, "d");
+            return;
+        case INFIX_PRIMITIVE_LONG_DOUBLE:
+            _print(state, "e");
+            return;
+        }
+    }
+
+    // Substitutions. Check if this complex type (Pointer/Struct) was already seen.
     size_t sub_index;
     bool is_builtin = (type->category == INFIX_TYPE_VOID || type->category == INFIX_TYPE_PRIMITIVE);
 
@@ -1466,63 +1555,12 @@ static void _infix_type_print_itanium_recursive(printer_state * state, const inf
         return;
     }
 
+    // Complex types
     switch (type->category) {
-    case INFIX_TYPE_VOID:
-        _print(state, "v");
-        break;
     case INFIX_TYPE_POINTER:
         _print(state, "P");
         _infix_type_print_itanium_recursive(state, type->meta.pointer_info.pointee_type);
         _add_itanium_sub(state, type);
-        break;
-    case INFIX_TYPE_PRIMITIVE:
-        switch (type->meta.primitive_id) {
-        case INFIX_PRIMITIVE_BOOL:
-            _print(state, "b");
-            break;
-        case INFIX_PRIMITIVE_SINT8:
-            _print(state, "a");
-            break;  // signed char
-        case INFIX_PRIMITIVE_UINT8:
-            _print(state, "h");
-            break;  // unsigned char
-        case INFIX_PRIMITIVE_SINT16:
-            _print(state, "s");
-            break;  // short
-        case INFIX_PRIMITIVE_UINT16:
-            _print(state, "t");
-            break;  // unsigned short
-        case INFIX_PRIMITIVE_SINT32:
-            _print(state, "i");
-            break;  // int
-        case INFIX_PRIMITIVE_UINT32:
-            _print(state, "j");
-            break;  // unsigned int
-        case INFIX_PRIMITIVE_SINT64:
-            _print(state, "x");
-            break;  // long long
-        case INFIX_PRIMITIVE_UINT64:
-            _print(state, "y");
-            break;  // unsigned long long
-        case INFIX_PRIMITIVE_SINT128:
-            _print(state, "n");
-            break;  // __int128
-        case INFIX_PRIMITIVE_UINT128:
-            _print(state, "o");
-            break;  // unsigned __int128
-        case INFIX_PRIMITIVE_FLOAT16:
-            _print(state, "Dh");
-            break;  // half-precision float (IEEE 754)
-        case INFIX_PRIMITIVE_FLOAT:
-            _print(state, "f");
-            break;
-        case INFIX_PRIMITIVE_DOUBLE:
-            _print(state, "d");
-            break;
-        case INFIX_PRIMITIVE_LONG_DOUBLE:
-            _print(state, "e");
-            break;
-        }
         break;
     case INFIX_TYPE_NAMED_REFERENCE:
         {
@@ -1610,11 +1648,66 @@ static void _infix_type_print_msvc_recursive(printer_state * state, const infix_
         return;
     }
 
+    // Built-in types: Use MSVC ABI codes immediately.
+    if (type->category == INFIX_TYPE_VOID) {
+        _print(state, "X");
+        return;
+    }
+
+    if (type->category == INFIX_TYPE_PRIMITIVE) {
+        switch (type->meta.primitive_id) {
+        case INFIX_PRIMITIVE_BOOL:
+            _print(state, "_N");
+            return;
+        case INFIX_PRIMITIVE_SINT8:
+            _print(state, "C");
+            return;
+        case INFIX_PRIMITIVE_UINT8:
+            _print(state, "E");
+            return;
+        case INFIX_PRIMITIVE_SINT16:
+            _print(state, "F");
+            return;
+        case INFIX_PRIMITIVE_UINT16:
+            _print(state, "G");
+            return;
+        case INFIX_PRIMITIVE_SINT32:
+            _print(state, "H");
+            return;
+        case INFIX_PRIMITIVE_UINT32:
+            _print(state, "I");
+            return;
+        case INFIX_PRIMITIVE_SINT64:
+            _print(state, "_J");
+            return;
+        case INFIX_PRIMITIVE_UINT64:
+            _print(state, "_K");
+            return;
+        case INFIX_PRIMITIVE_SINT128:
+            _print(state, "_L");
+            return;
+        case INFIX_PRIMITIVE_UINT128:
+            _print(state, "_M");
+            return;
+        case INFIX_PRIMITIVE_FLOAT16:
+            _print(state, "_T");
+            return;
+        case INFIX_PRIMITIVE_FLOAT:
+            _print(state, "M");
+            return;
+        case INFIX_PRIMITIVE_DOUBLE:
+            _print(state, "N");
+            return;
+        case INFIX_PRIMITIVE_LONG_DOUBLE:
+            _print(state, "O");
+            return;
+        }
+    }
+
     // Check for type back-references (0-9)
     // MSVC only back-references complex types or pointers to them.
-    bool can_backref =
-        (type->category == INFIX_TYPE_POINTER || type->category == INFIX_TYPE_STRUCT ||
-         type->category == INFIX_TYPE_UNION || type->category == INFIX_TYPE_ENUM || type->name != nullptr);
+    bool can_backref = (type->category == INFIX_TYPE_POINTER || type->category == INFIX_TYPE_STRUCT ||
+                        type->category == INFIX_TYPE_UNION || type->category == INFIX_TYPE_ENUM);
 
     if (can_backref) {
         for (size_t i = 0; i < state->msvc_type_count; i++) {
@@ -1683,9 +1776,6 @@ static void _infix_type_print_msvc_recursive(printer_state * state, const infix_
     }
 
     switch (type->category) {
-    case INFIX_TYPE_VOID:
-        _print(state, "X");
-        break;
     case INFIX_TYPE_POINTER:
         // Standard MSVC pointer encoding for x64:
         // P = Pointer
@@ -1712,55 +1802,6 @@ static void _infix_type_print_msvc_recursive(printer_state * state, const infix_
         _print(state, "@Z");
         if (can_backref && state->msvc_type_count < 10)
             state->msvc_types[state->msvc_type_count++] = type;
-        break;
-    case INFIX_TYPE_PRIMITIVE:
-        switch (type->meta.primitive_id) {
-        case INFIX_PRIMITIVE_BOOL:
-            _print(state, "_N");
-            break;
-        case INFIX_PRIMITIVE_SINT8:
-            _print(state, "C");
-            break;
-        case INFIX_PRIMITIVE_UINT8:
-            _print(state, "E");
-            break;
-        case INFIX_PRIMITIVE_SINT16:
-            _print(state, "F");
-            break;
-        case INFIX_PRIMITIVE_UINT16:
-            _print(state, "G");
-            break;
-        case INFIX_PRIMITIVE_SINT32:
-            _print(state, "H");
-            break;
-        case INFIX_PRIMITIVE_UINT32:
-            _print(state, "I");
-            break;
-        case INFIX_PRIMITIVE_SINT64:
-            _print(state, "_J");
-            break;
-        case INFIX_PRIMITIVE_UINT64:
-            _print(state, "_K");
-            break;
-        case INFIX_PRIMITIVE_SINT128:
-            _print(state, "_L");
-            break;
-        case INFIX_PRIMITIVE_UINT128:
-            _print(state, "_M");
-            break;
-        case INFIX_PRIMITIVE_FLOAT16:
-            _print(state, "_T");
-            break;
-        case INFIX_PRIMITIVE_FLOAT:
-            _print(state, "M");
-            break;
-        case INFIX_PRIMITIVE_DOUBLE:
-            _print(state, "N");
-            break;
-        case INFIX_PRIMITIVE_LONG_DOUBLE:
-            _print(state, "O");
-            break;
-        }
         break;
     case INFIX_TYPE_COMPLEX:
         // MSVC doesn't have a built-in complex type, it uses structs.

--- a/src/core/types.c
+++ b/src/core/types.c
@@ -1230,7 +1230,12 @@ size_t _infix_estimate_graph_size(infix_arena_t * temp_arena, const infix_type *
 INFIX_API c23_nodiscard const char * infix_type_get_name(const infix_type * type) {
     if (type == nullptr)
         return nullptr;
-    return type->name;
+    if (type->name)
+        return type->name;
+    // Add this check so Affix can inspect unresolved types!
+    if (type->category == INFIX_TYPE_NAMED_REFERENCE)
+        return type->meta.named_reference.name;
+    return nullptr;
 }
 /**
  * @brief Gets the fundamental category of a type.

--- a/t/004_signatures.c
+++ b/t/004_signatures.c
@@ -381,7 +381,7 @@ TEST {
         infix_registry_destroy(registry);
     }
     subtest("Round trip") {
-        plan(7);
+        plan(11);
         test_print_roundtrip("int", "sint32");
         test_print_roundtrip("*[10:{int,float}]", "*[10:{sint32,float}]");
         test_print_roundtrip("<*void, double>", NULL);
@@ -389,6 +389,10 @@ TEST {
         test_print_roundtrip("{<int,char>, *char}", "{<sint32,sint8>,*sint8}");
         test_print_roundtrip("e:longlong", "e:sint64");
         test_print_roundtrip("v[4:float]", NULL);
+        test_print_roundtrip("wchar_t", "wchar_t");  // Should NOT print as @wchar_t
+        test_print_roundtrip("char16_t", "char16_t");
+        test_print_roundtrip("char32_t", "char32_t");
+        test_print_roundtrip("[16:wchar_t]", "[16:wchar_t]");
     }
     subtest("Round trip with named fields") {
         plan(3);

--- a/t/007_type_registry.c
+++ b/t/007_type_registry.c
@@ -182,7 +182,7 @@ TEST {
         infix_registry_destroy(registry);
     }
     subtest("Semantic Aliases for Non-Aggregate Types") {
-        plan(10);
+        plan(11);
         note("Verifies that aliases for primitives and pointers preserve their name for introspection.");
         infix_registry_t * registry = infix_registry_create();
         const char * defs = "@MyInt = int32; @MyHandle = *void; @MyPoint = {double, double}; @MyPointAlias = @MyPoint;";
@@ -223,6 +223,28 @@ TEST {
         infix_arena_destroy(arena2);
         infix_arena_destroy(arena3);
         infix_registry_destroy(registry);
+
+        subtest("Named Primitives vs Registry Aliases") {
+            plan(5);
+            infix_registry_t * registry = infix_registry_create();
+            const char * defs = "@MyInt = int;";
+            ok(infix_register_types(registry, defs) == INFIX_SUCCESS, "Registered aliases for int");
+
+            infix_type * type = NULL;
+            infix_arena_t * arena = NULL;
+
+            // Registry Alias: should have a name and be a STRUCT/PRIMITIVE depending on resolution
+            ok(infix_type_from_signature(&type, &arena, "@MyInt", registry) == INFIX_SUCCESS, "Parse @MyInt");
+            ok(strcmp(infix_type_get_name(type), "MyInt") == 0, "Registry alias name preserved");
+            infix_arena_destroy(arena);
+
+            // Primitive Alias: should have a name natively now
+            ok(infix_type_from_signature(&type, &arena, "wchar_t", NULL) == INFIX_SUCCESS, "Parse wchar_t");
+            ok(strcmp(infix_type_get_name(type), "wchar_t") == 0, "Primitive alias 'wchar_t' name preserved natively");
+            infix_arena_destroy(arena);
+
+            infix_registry_destroy(registry);
+        }
     }
 
     subtest("Cloning a populated registry") {

--- a/t/008_registry_introspection.c
+++ b/t/008_registry_introspection.c
@@ -28,7 +28,7 @@
 #include <string.h>
 
 TEST {
-    plan(3);
+    plan(4);
     // Setup: Create a registry with a mix of types.
     infix_registry_t * registry = infix_registry_create();
     if (!registry)
@@ -102,5 +102,21 @@ TEST {
            "`lookup_type` returns correct type for @Point");
         ok(infix_registry_lookup_type(registry, "FwdOnly") == NULL, "`lookup_type` returns NULL for fwd-declaration");
     }
+    subtest("Registry Print with Named Primitives") {
+        plan(3);
+        infix_registry_t * reg = infix_registry_create();
+        ok(infix_register_types(reg, "@StringNode = { text: [32:wchar_t] };") == INFIX_SUCCESS,
+           "Registered StringNode");
+
+        char buf[256];
+        infix_status s = infix_registry_print(buf, sizeof(buf), reg);
+        if (ok(s == INFIX_SUCCESS, "Registry print succeeds")) {
+            // The output should contain WChar, NOT @WChar
+            ok(strstr(buf, "{text:[32:wchar_t]}") != NULL, "Registry dump uses native primitive name 'wchar_t'");
+        }
+
+        infix_registry_destroy(reg);
+    }
+
     infix_registry_destroy(registry);
 }


### PR DESCRIPTION
- The string parser now preserves names for character-specific primitives (`wchar_t`, `char16_t`, `char32_t`, and `char8_t`). This prevents semantic erasure where these types were previously indistinguishable from raw integers.
- Updated `infix_type_get_name()` to return the alias name for these specific primitives, enabling high-level marshallers to correctly identify string buffers without relying on fragile `sizeof()` heuristics.